### PR TITLE
Guards fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Railway.Create()` — two-phase builder factory** that enforces a clear separation between the
+  guard/validation phase and the step execution phase at the type-system level
+  - `Railway.Create(factory, selector, guards, steps)` — with guards
+  - `Railway.Create(factory, selector, steps)` — without guards (convenience overload)
+  - Parameterless variants (`Func<TPayload>` factory) for railways with no request input
+  - New `RailwayGuardBuilder<...>` — only exposes `Guard()` and `Validate()`
+  - New `RailwayStepsBuilder<...>` — only exposes `Do()`, `DoIf()`, `DoAll()`, `Group()`,
+    `WithContext()`, `Detach()`, `Parallel()`, `ParallelDetached()`, `Finally()`, and `Build()`
+
+### Fixed
+
+- **Registration-order bug**: `Group()`, `WithContext()`, `Detach()`, `Parallel()`, and
+  `ParallelDetached()` steps now execute in the exact order they were registered, interleaved
+  correctly with `Do()` steps. Previously all `Do()` steps ran before all feature steps
+  regardless of registration order.
+
+### Deprecated
+
+- `RailwayBuilder<TRequest, TPayload, TSuccess, TError>` — use `Railway.Create()` instead
+- `RailwayBuilderFactory` — use `Railway.Create()` instead
+
 ## [3.4.1] - 2026-03-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -32,28 +32,27 @@ dotnet add package Zooper.Bee
 
 ```csharp
 // Define a simple railway
-var railway = new RailwayBuilder<Request, Payload, SuccessResult, ErrorResult>(
+var railway = Railway.Create<Request, Payload, SuccessResult, ErrorResult>(
     // Factory function that creates the initial payload from the request
-    request => new Payload { Data = request.Data },
+    factory:  request => new Payload { Data = request.Data },
 
     // Selector function that creates the success result from the final payload
-    payload => new SuccessResult { ProcessedData = payload.Data }
-)
-.Validate(request =>
-{
-    // Validate the request
-    if (string.IsNullOrEmpty(request.Data))
-        return Option<ErrorResult>.Some(new ErrorResult { Message = "Data is required" });
+    selector: payload => new SuccessResult { ProcessedData = payload.Data },
 
-    return Option<ErrorResult>.None;
-})
-.Do(payload =>
-{
-    // Process the payload
-    payload.Data = payload.Data.ToUpper();
-    return Either<ErrorResult, Payload>.FromRight(payload);
-})
-.Build();
+    // Step execution phase
+    steps: s => s
+        .Validate(request =>
+        {
+            if (string.IsNullOrEmpty(request.Data))
+                return Option<ErrorResult>.Some(new ErrorResult { Message = "Data is required" });
+            return Option<ErrorResult>.None;
+        })
+        .Do(payload =>
+        {
+            payload.Data = payload.Data.ToUpper();
+            return Either<ErrorResult, Payload>.FromRight(payload);
+        })
+);
 
 // Execute the railway
 var result = await railway.Execute(new Request { Data = "hello world" }, CancellationToken.None);
@@ -69,9 +68,45 @@ else
 
 ## Building Railways
 
+Railways are created with `Railway.Create()`, which takes two separate configuration lambdas:
+
+- **`guards`** — optional; declares guards and validations that run before the payload is created
+- **`steps`** — required; declares all activities that transform the payload
+
+This two-phase separation makes it structurally impossible to mix guard registration with step
+registration. `Guard()` and `Validate()` are not available inside `steps`, and `Do()`/`Group()`/etc.
+are not available inside `guards`.
+
+```csharp
+var railway = Railway.Create<Request, Payload, Success, Error>(
+    factory:  request => new Payload(request),
+    selector: payload => new Success(payload.Result),
+    guards: g => g
+        .Guard(request => /* auth check */)
+        .Validate(request => /* input validation */),
+    steps: s => s
+        .Do(payload => /* step 1 */)
+        .Group(null, g => g
+            .Do(payload => /* step 2a */)
+            .Do(payload => /* step 2b */))
+        .Do(payload => /* step 3 */)
+);
+```
+
+When no guards are needed, omit the `guards` parameter:
+
+```csharp
+var railway = Railway.Create<Request, Payload, Success, Error>(
+    factory:  request => new Payload(request),
+    selector: payload => new Success(payload.Result),
+    steps: s => s
+        .Do(payload => /* ... */)
+);
+```
+
 ### Validation
 
-Validates the incoming request before processing begins.
+Validations run before any step and reject the request early when invalid.
 
 ```csharp
 // Asynchronous validation
@@ -91,31 +126,36 @@ Validates the incoming request before processing begins.
 
 ### Guards
 
-Guards allow you to define checks that run before a railway begins execution. They're ideal for authentication,
-authorization, account validation, or any other requirement that must be satisfied before a railway can proceed.
+Guards check whether the railway is allowed to execute at all — authentication,
+authorization, feature flags, etc. They always run before any step, regardless of
+where they appear in the `guards` lambda.
 
 ```csharp
-// Asynchronous guard
-.Guard(async (request, cancellationToken) =>
-{
-    var isAuthorized = await CheckAuthorizationAsync(request, cancellationToken);
-    return isAuthorized ? Option<ErrorResult>.None : Option<ErrorResult>.Some(new ErrorResult());
-})
-
-// Synchronous guard
-.Guard(request =>
-{
-    var isAuthorized = CheckAuthorization(request);
-    return isAuthorized ? Option<ErrorResult>.None : Option<ErrorResult>.Some(new ErrorResult());
-})
+guards: g => g
+    // Asynchronous guard
+    .Guard(async (request, cancellationToken) =>
+    {
+        var isAuthorized = await CheckAuthorizationAsync(request, cancellationToken);
+        return isAuthorized
+            ? Either<ErrorResult, Unit>.FromRight(Unit.Value)
+            : Either<ErrorResult, Unit>.FromLeft(new ErrorResult { Message = "Unauthorized" });
+    })
+    // Synchronous guard
+    .Guard(request =>
+    {
+        var isAuthorized = CheckAuthorization(request);
+        return isAuthorized
+            ? Either<ErrorResult, Unit>.FromRight(Unit.Value)
+            : Either<ErrorResult, Unit>.FromLeft(new ErrorResult { Message = "Unauthorized" });
+    })
 ```
 
 #### Benefits of Guards
 
-- Guards run before creating the railway context, providing early validation
-- They provide a clear separation between "can this railway run?" and the actual railway logic
+- Guards run before the payload is created, providing the earliest possible short-circuit
+- The `guards` phase is structurally separate from the `steps` phase — it is impossible to
+  accidentally register a guard after a step
 - Common checks like authentication can be standardized and reused
-- Failures short-circuit the railway, preventing unnecessary work
 
 ### Activities
 
@@ -348,6 +388,38 @@ services.AddRailways(lifetime: ServiceLifetime.Singleton);
 5. Use `Finally` for cleanup operations
 6. Validate requests early to fail fast
 7. Use contextual state to avoid passing too many parameters
+
+## Migration from `RailwayBuilder` to `Railway.Create()`
+
+As of the latest version, `RailwayBuilder` and `RailwayBuilderFactory` are `[Obsolete]`.
+Use `Railway.Create()` instead.
+
+### Before
+
+```csharp
+var railway = new RailwayBuilder<Request, Payload, Success, Error>(
+        request => new Payload(request),
+        payload => new Success(payload.Result))
+    .Guard(request => /* ... */)
+    .Validate(request => /* ... */)
+    .Do(payload => /* ... */)
+    .Group(null, g => g.Do(payload => /* ... */))
+    .Build();
+```
+
+### After
+
+```csharp
+var railway = Railway.Create<Request, Payload, Success, Error>(
+    factory:  request => new Payload(request),
+    selector: payload => new Success(payload.Result),
+    guards: g => g
+        .Guard(request => /* ... */)
+        .Validate(request => /* ... */),
+    steps: s => s
+        .Do(payload => /* ... */)
+        .Group(null, g => g.Do(payload => /* ... */)));
+```
 
 ## Migration from Workflow to Railway
 

--- a/Zooper.Bee.Tests/BranchWithLocalPayloadTests.cs
+++ b/Zooper.Bee.Tests/BranchWithLocalPayloadTests.cs
@@ -196,7 +196,7 @@ public class ContextTests
 
 		// Assert
 		result.IsRight.Should().BeTrue();
-		result.Right.ProcessingResult.Should().Be("Initial processing -> Main activity -> Context 1 -> Context 2");
+		result.Right.ProcessingResult.Should().Be("Initial processing -> Context 1 -> Main activity -> Context 2");
 		result.Right.FinalPrice.Should().Be(130.00m); // Base (100) + Context 1 (10) + Context 2 (20)
 	}
 

--- a/Zooper.Bee.Tests/RailwayWithContextTests.cs
+++ b/Zooper.Bee.Tests/RailwayWithContextTests.cs
@@ -225,7 +225,7 @@ public class RailwayWithContextTests
 
 		// Assert
 		result.IsRight.Should().BeTrue();
-		result.Right.ProcessingResult.Should().Be("Initial processing -> Main activity -> Context 1 -> Context 2");
+		result.Right.ProcessingResult.Should().Be("Initial processing -> Context 1 -> Main activity -> Context 2");
 		result.Right.FinalPrice.Should().Be(130.00m); // 100 + 10 + 20
 		result.Right.CustomizationDetails.Should().Be("Context 1 customization + Context 2 customization");
 	}

--- a/Zooper.Bee.Tests/Zooper.Bee.Tests.csproj
+++ b/Zooper.Bee.Tests/Zooper.Bee.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/Zooper.Bee/Features/Context/ContextBuilder.cs
+++ b/Zooper.Bee/Features/Context/ContextBuilder.cs
@@ -15,14 +15,10 @@ namespace Zooper.Bee.Features.Context;
 /// <typeparam name="TError">The type of the error result</typeparam>
 public sealed class ContextBuilder<TRequest, TPayload, TLocalState, TSuccess, TError>
 {
-	private readonly RailwayBuilder<TRequest, TPayload, TSuccess, TError> _workflow;
 	private readonly Context<TPayload, TLocalState, TError> _context;
 
-	internal ContextBuilder(
-		RailwayBuilder<TRequest, TPayload, TSuccess, TError> workflow,
-		Context<TPayload, TLocalState, TError> context)
+	internal ContextBuilder(Context<TPayload, TLocalState, TError> context)
 	{
-		_workflow = workflow;
 		_context = context;
 	}
 

--- a/Zooper.Bee/Features/Detached/DetachedBuilder.cs
+++ b/Zooper.Bee/Features/Detached/DetachedBuilder.cs
@@ -15,14 +15,10 @@ namespace Zooper.Bee.Features.Detached;
 /// <typeparam name="TError">The type of the error result</typeparam>
 public sealed class DetachedBuilder<TRequest, TPayload, TSuccess, TError>
 {
-	private readonly RailwayBuilder<TRequest, TPayload, TSuccess, TError> _workflow;
 	private readonly Detached<TPayload, TError> _detached;
 
-	internal DetachedBuilder(
-		RailwayBuilder<TRequest, TPayload, TSuccess, TError> workflow,
-		Detached<TPayload, TError> detached)
+	internal DetachedBuilder(Detached<TPayload, TError> detached)
 	{
-		_workflow = workflow;
 		_detached = detached;
 	}
 

--- a/Zooper.Bee/Features/Group/GroupBuilder.cs
+++ b/Zooper.Bee/Features/Group/GroupBuilder.cs
@@ -15,14 +15,10 @@ namespace Zooper.Bee.Features.Group;
 /// <typeparam name="TError">The type of the error result</typeparam>
 public sealed class GroupBuilder<TRequest, TPayload, TSuccess, TError>
 {
-	private readonly RailwayBuilder<TRequest, TPayload, TSuccess, TError> _workflow;
 	private readonly Group<TPayload, TError> _group;
 
-	internal GroupBuilder(
-		RailwayBuilder<TRequest, TPayload, TSuccess, TError> workflow,
-		Group<TPayload, TError> group)
+	internal GroupBuilder(Group<TPayload, TError> group)
 	{
-		_workflow = workflow;
 		_group = group;
 	}
 

--- a/Zooper.Bee/Features/Parallel/ParallelBuilder.cs
+++ b/Zooper.Bee/Features/Parallel/ParallelBuilder.cs
@@ -12,14 +12,10 @@ namespace Zooper.Bee.Features.Parallel;
 /// <typeparam name="TError">The type of the error result</typeparam>
 public sealed class ParallelBuilder<TRequest, TPayload, TSuccess, TError>
 {
-	private readonly RailwayBuilder<TRequest, TPayload, TSuccess, TError> _workflow;
 	private readonly Parallel<TPayload, TError> _parallel;
 
-	internal ParallelBuilder(
-		RailwayBuilder<TRequest, TPayload, TSuccess, TError> workflow,
-		Parallel<TPayload, TError> parallel)
+	internal ParallelBuilder(Parallel<TPayload, TError> parallel)
 	{
-		_workflow = workflow;
 		_parallel = parallel;
 	}
 
@@ -34,7 +30,7 @@ public sealed class ParallelBuilder<TRequest, TPayload, TSuccess, TError>
 		var group = new Group<TPayload, TError>();
 		_parallel.Groups.Add(group);
 
-		var groupBuilder = new GroupBuilder<TRequest, TPayload, TSuccess, TError>(_workflow, group);
+		var groupBuilder = new GroupBuilder<TRequest, TPayload, TSuccess, TError>(group);
 		groupConfiguration(groupBuilder);
 
 		return this;
@@ -53,7 +49,7 @@ public sealed class ParallelBuilder<TRequest, TPayload, TSuccess, TError>
 		var group = new Group<TPayload, TError>(condition);
 		_parallel.Groups.Add(group);
 
-		var groupBuilder = new GroupBuilder<TRequest, TPayload, TSuccess, TError>(_workflow, group);
+		var groupBuilder = new GroupBuilder<TRequest, TPayload, TSuccess, TError>(group);
 		groupConfiguration(groupBuilder);
 
 		return this;

--- a/Zooper.Bee/Features/Parallel/ParallelDetachedBuilder.cs
+++ b/Zooper.Bee/Features/Parallel/ParallelDetachedBuilder.cs
@@ -12,14 +12,10 @@ namespace Zooper.Bee.Features.Parallel;
 /// <typeparam name="TError">The type of the error result</typeparam>
 public sealed class ParallelDetachedBuilder<TRequest, TPayload, TSuccess, TError>
 {
-	private readonly RailwayBuilder<TRequest, TPayload, TSuccess, TError> _workflow;
 	private readonly ParallelDetached<TPayload, TError> _parallelDetached;
 
-	internal ParallelDetachedBuilder(
-		RailwayBuilder<TRequest, TPayload, TSuccess, TError> workflow,
-		ParallelDetached<TPayload, TError> parallelDetached)
+	internal ParallelDetachedBuilder(ParallelDetached<TPayload, TError> parallelDetached)
 	{
-		_workflow = workflow;
 		_parallelDetached = parallelDetached;
 	}
 
@@ -34,7 +30,7 @@ public sealed class ParallelDetachedBuilder<TRequest, TPayload, TSuccess, TError
 		var detached = new Detached<TPayload, TError>();
 		_parallelDetached.DetachedGroups.Add(detached);
 
-		var detachedBuilder = new DetachedBuilder<TRequest, TPayload, TSuccess, TError>(_workflow, detached);
+		var detachedBuilder = new DetachedBuilder<TRequest, TPayload, TSuccess, TError>(detached);
 		detachedConfiguration(detachedBuilder);
 
 		return this;
@@ -53,7 +49,7 @@ public sealed class ParallelDetachedBuilder<TRequest, TPayload, TSuccess, TError
 		var detached = new Detached<TPayload, TError>(condition);
 		_parallelDetached.DetachedGroups.Add(detached);
 
-		var detachedBuilder = new DetachedBuilder<TRequest, TPayload, TSuccess, TError>(_workflow, detached);
+		var detachedBuilder = new DetachedBuilder<TRequest, TPayload, TSuccess, TError>(detached);
 		detachedConfiguration(detachedBuilder);
 
 		return this;

--- a/Zooper.Bee/RailwayBuilder.cs
+++ b/Zooper.Bee/RailwayBuilder.cs
@@ -24,6 +24,7 @@ namespace Zooper.Bee;
 /// <remarks>
 /// Initializes a new instance of the <see cref="RailwayBuilder{TRequest, TPayload, TSuccess, TError}"/> class.
 /// </remarks>
+[Obsolete("Use Railway.Create() instead, which enforces a clear separation between the guard/validation phase and the step execution phase.")]
 public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 {
 	private readonly Func<TRequest, TPayload> _contextFactory;
@@ -31,14 +32,11 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 
 	private readonly List<RailwayGuard<TRequest, TError>> _guards = [];
 	private readonly List<RailwayValidation<TRequest, TError>> _validations = [];
-	private readonly List<RailwayStep<TPayload, TError>> _activities = [];
-	private readonly List<ConditionalRailwayStep<TPayload, TError>> _conditionalActivities = [];
+	private readonly List<Func<TPayload, CancellationToken, Task<Either<TError, TPayload>>>> _steps = [];
+	private readonly FeatureExecutorFactory<TPayload, TError> _featureExecutorFactory = new();
 	private readonly List<RailwayStep<TPayload, TError>> _finallyActivities = [];
 	private readonly List<Branch<TPayload, TError>> _branches = [];
 	private readonly List<object> _branchesWithLocalPayload = [];
-
-	// Collections for new features
-	private readonly List<IRailwayFeature<TPayload, TError>> _features = [];
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="RailwayBuilder{TRequest, TPayload, TSuccess, TError}"/> class.
@@ -125,7 +123,7 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 	public RailwayBuilder<TRequest, TPayload, TSuccess, TError> Do(
 		Func<TPayload, CancellationToken, Task<Either<TError, TPayload>>> activity)
 	{
-		_activities.Add(new(activity));
+		_steps.Add(activity);
 		return this;
 	}
 
@@ -136,12 +134,7 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 	/// <returns>The builder instance for method chaining</returns>
 	public RailwayBuilder<TRequest, TPayload, TSuccess, TError> Do(Func<TPayload, Either<TError, TPayload>> activity)
 	{
-		_activities.Add(
-			new((
-					payload,
-					_) => Task.FromResult(activity(payload))
-			)
-		);
+		_steps.Add((payload, _) => Task.FromResult(activity(payload)));
 		return this;
 	}
 
@@ -155,7 +148,7 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 	{
 		foreach (var activity in activities)
 		{
-			_activities.Add(new(activity));
+			_steps.Add(activity);
 		}
 
 		return this;
@@ -170,12 +163,7 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 	{
 		foreach (var activity in activities)
 		{
-			_activities.Add(
-				new((
-						payload,
-						_) => Task.FromResult(activity(payload))
-				)
-			);
+			_steps.Add((payload, _) => Task.FromResult(activity(payload)));
 		}
 
 		return this;
@@ -191,12 +179,10 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 		Func<TPayload, bool> condition,
 		Func<TPayload, CancellationToken, Task<Either<TError, TPayload>>> activity)
 	{
-		_conditionalActivities.Add(
-			new(
-				condition,
-				new(activity)
-			)
-		);
+		_steps.Add((payload, ct) =>
+			condition(payload)
+				? activity(payload, ct)
+				: Task.FromResult(Either<TError, TPayload>.FromRight(payload)));
 		return this;
 	}
 
@@ -210,15 +196,10 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 		Func<TPayload, bool> condition,
 		Func<TPayload, Either<TError, TPayload>> activity)
 	{
-		_conditionalActivities.Add(
-			new(
-				condition,
-				new((
-						payload,
-						_) => Task.FromResult(activity(payload))
-				)
-			)
-		);
+		_steps.Add((payload, _) =>
+			Task.FromResult(condition(payload)
+				? activity(payload)
+				: Either<TError, TPayload>.FromRight(payload)));
 		return this;
 	}
 
@@ -276,9 +257,9 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 		Action<Features.Group.GroupBuilder<TRequest, TPayload, TSuccess, TError>> groupConfiguration)
 	{
 		var group = new Features.Group.Group<TPayload, TError>(condition);
-		_features.Add(group);
-		var groupBuilder = new Features.Group.GroupBuilder<TRequest, TPayload, TSuccess, TError>(this, group);
+		var groupBuilder = new Features.Group.GroupBuilder<TRequest, TPayload, TSuccess, TError>(group);
 		groupConfiguration(groupBuilder);
+		_steps.Add((payload, ct) => ExecuteFeatureStepAsync(group, payload, ct));
 		return this;
 	}
 
@@ -377,9 +358,9 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 		Action<Features.Context.ContextBuilder<TRequest, TPayload, TLocalState, TSuccess, TError>> contextConfiguration)
 	{
 		var context = new Features.Context.Context<TPayload, TLocalState, TError>(condition, localStateFactory);
-		_features.Add(context);
-		var contextBuilder = new Features.Context.ContextBuilder<TRequest, TPayload, TLocalState, TSuccess, TError>(this, context);
+		var contextBuilder = new Features.Context.ContextBuilder<TRequest, TPayload, TLocalState, TSuccess, TError>(context);
 		contextConfiguration(contextBuilder);
+		_steps.Add((payload, ct) => ExecuteFeatureStepAsync(context, payload, ct));
 		return this;
 	}
 
@@ -409,9 +390,9 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 		Action<Features.Detached.DetachedBuilder<TRequest, TPayload, TSuccess, TError>> detachedConfiguration)
 	{
 		var detached = new Features.Detached.Detached<TPayload, TError>(condition);
-		_features.Add(detached);
-		var detachedBuilder = new Features.Detached.DetachedBuilder<TRequest, TPayload, TSuccess, TError>(this, detached);
+		var detachedBuilder = new Features.Detached.DetachedBuilder<TRequest, TPayload, TSuccess, TError>(detached);
 		detachedConfiguration(detachedBuilder);
+		_steps.Add((payload, ct) => ExecuteFeatureStepAsync(detached, payload, ct));
 		return this;
 	}
 
@@ -439,9 +420,9 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 		Action<Features.Parallel.ParallelBuilder<TRequest, TPayload, TSuccess, TError>> parallelConfiguration)
 	{
 		var parallel = new Features.Parallel.Parallel<TPayload, TError>(condition);
-		_features.Add(parallel);
-		var parallelBuilder = new Features.Parallel.ParallelBuilder<TRequest, TPayload, TSuccess, TError>(this, parallel);
+		var parallelBuilder = new Features.Parallel.ParallelBuilder<TRequest, TPayload, TSuccess, TError>(parallel);
 		parallelConfiguration(parallelBuilder);
+		_steps.Add((payload, ct) => ExecuteFeatureStepAsync(parallel, payload, ct));
 		return this;
 	}
 
@@ -469,10 +450,10 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 		Action<Features.Parallel.ParallelDetachedBuilder<TRequest, TPayload, TSuccess, TError>> parallelDetachedConfiguration)
 	{
 		var parallelDetached = new Features.Parallel.ParallelDetached<TPayload, TError>(condition);
-		_features.Add(parallelDetached);
 		var parallelDetachedBuilder =
-			new Features.Parallel.ParallelDetachedBuilder<TRequest, TPayload, TSuccess, TError>(this, parallelDetached);
+			new Features.Parallel.ParallelDetachedBuilder<TRequest, TPayload, TSuccess, TError>(parallelDetached);
 		parallelDetachedConfiguration(parallelDetachedBuilder);
+		_steps.Add((payload, ct) => ExecuteFeatureStepAsync(parallelDetached, payload, ct));
 		return this;
 	}
 
@@ -551,17 +532,11 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 
 		try
 		{
-			var activitiesResult = await RunActivitiesAsync(payload, cancellationToken);
-			if (activitiesResult.IsLeft)
-				return Either<TError, TSuccess>.FromLeft(activitiesResult.Left!);
+			var stepsResult = await RunStepsAsync(payload, cancellationToken);
+			if (stepsResult.IsLeft)
+				return Either<TError, TSuccess>.FromLeft(stepsResult.Left!);
 
-			payload = activitiesResult.Right!;
-
-			var conditionalResult = await RunConditionalActivitiesAsync(payload, cancellationToken);
-			if (conditionalResult.IsLeft)
-				return Either<TError, TSuccess>.FromLeft(conditionalResult.Left!);
-
-			payload = conditionalResult.Right!;
+			payload = stepsResult.Right!;
 
 			var branchesResult = await RunBranchesAsync(payload, cancellationToken);
 			if (branchesResult.IsLeft)
@@ -574,12 +549,6 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 				return Either<TError, TSuccess>.FromLeft(branchLocalsResult.Left!);
 
 			payload = branchLocalsResult.Right!;
-
-			var featuresResult = await RunFeaturesAsync(payload, cancellationToken);
-			if (featuresResult.IsLeft)
-				return Either<TError, TSuccess>.FromLeft(featuresResult.Left!);
-
-			payload = featuresResult.Right!;
 
 			var successValue = _resultSelector(payload);
 			return Either<TError, TSuccess>.FromRight(successValue ?? default!);
@@ -635,20 +604,20 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 	}
 
 	/// <summary>
-	/// Executes all registered activities in sequence, returning either the first encountered error or the transformed payload.
+	/// Executes all registered steps in insertion order, returning either the first encountered error or the transformed payload.
 	/// </summary>
 	/// <param name="payload">The initial payload to process.</param>
 	/// <param name="cancellationToken">Token to observe for cancellation.</param>
 	/// <returns>
-	/// An Either containing the error (Left) if any activity fails, or the final payload (Right) on success.
+	/// An Either containing the error (Left) if any step fails, or the final payload (Right) on success.
 	/// </returns>
-	private async Task<Either<TError, TPayload>> RunActivitiesAsync(
+	private async Task<Either<TError, TPayload>> RunStepsAsync(
 		TPayload payload,
 		CancellationToken cancellationToken)
 	{
-		foreach (var activity in _activities)
+		foreach (var step in _steps)
 		{
-			var result = await activity.Execute(payload, cancellationToken);
+			var result = await step(payload, cancellationToken);
 			if (result.IsLeft && result.Left != null)
 				return Either<TError, TPayload>.FromLeft(result.Left);
 
@@ -659,30 +628,27 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 	}
 
 	/// <summary>
-	/// Executes conditional activities when their condition is met.
+	/// Executes a feature as a step, respecting <see cref="IRailwayFeature{TPayload,TError}.ShouldMerge"/>.
 	/// </summary>
+	/// <param name="feature">The feature to execute.</param>
 	/// <param name="payload">The current payload.</param>
 	/// <param name="cancellationToken">Token to observe for cancellation.</param>
 	/// <returns>
-	/// An Either containing the error (Left) if any conditional activity fails, or the updated payload (Right) on success.
+	/// An Either containing the error (Left) if the feature fails, or the payload (Right) — merged when
+	/// <see cref="IRailwayFeature{TPayload,TError}.ShouldMerge"/> is <see langword="true"/>, unchanged otherwise.
 	/// </returns>
-	private async Task<Either<TError, TPayload>> RunConditionalActivitiesAsync(
+	private async Task<Either<TError, TPayload>> ExecuteFeatureStepAsync(
+		IRailwayFeature<TPayload, TError> feature,
 		TPayload payload,
 		CancellationToken cancellationToken)
 	{
-		foreach (var conditionalActivity in _conditionalActivities)
-		{
-			if (!conditionalActivity.ShouldExecute(payload))
-				continue;
+		var result = await _featureExecutorFactory.ExecuteFeature(feature, payload, cancellationToken);
+		if (result.IsLeft && result.Left != null)
+			return Either<TError, TPayload>.FromLeft(result.Left);
 
-			var result = await conditionalActivity.Activity.Execute(payload, cancellationToken);
-			if (result.IsLeft && result.Left != null)
-				return Either<TError, TPayload>.FromLeft(result.Left);
-
-			payload = result.Right!;
-		}
-
-		return Either<TError, TPayload>.FromRight(payload);
+		return feature.ShouldMerge
+			? Either<TError, TPayload>.FromRight(result.Right!)
+			: Either<TError, TPayload>.FromRight(payload);
 	}
 
 	/// <summary>
@@ -739,32 +705,7 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 		return Either<TError, TPayload>.FromRight(payload);
 	}
 
-	/// <summary>
-	/// Executes railway features like Group, Context, Detach, Parallel, merging results when applicable.
-	/// </summary>
-	/// <param name="payload">The current payload.</param>
-	/// <param name="cancellationToken">Token to observe for cancellation.</param>
-	/// <returns>
-	/// An Either containing the error (Left) if any feature fails, or the updated payload (Right) on success.
-	/// </returns>
-	private async Task<Either<TError, TPayload>> RunFeaturesAsync(
-		TPayload payload,
-		CancellationToken cancellationToken)
-	{
-		var factory = new FeatureExecutorFactory<TPayload, TError>();
 
-		foreach (var feature in _features)
-		{
-			var result = await factory.ExecuteFeature(feature, payload, cancellationToken);
-			if (result.IsLeft && result.Left != null)
-				return Either<TError, TPayload>.FromLeft(result.Left);
-
-			if (feature.ShouldMerge)
-				payload = result.Right!;
-		}
-
-		return Either<TError, TPayload>.FromRight(payload);
-	}
 
 	/// <summary>
 	/// Executes all the "finally" activities, ignoring errors.
@@ -802,7 +743,7 @@ public class RailwayBuilder<TRequest, TPayload, TSuccess, TError>
 		var branchType = branchObject.GetType();
 
 		if (branchType.IsGenericType &&
-		    branchType.GetGenericTypeDefinition() == typeof(BranchWithLocalPayload<,,>))
+			branchType.GetGenericTypeDefinition() == typeof(BranchWithLocalPayload<,,>))
 		{
 			var methodInfo = typeof(RailwayBuilder<TRequest, TPayload, TSuccess, TError>)
 				.GetMethod(nameof(ExecuteBranchWithLocalPayload), BindingFlags.NonPublic | BindingFlags.Instance);

--- a/Zooper.Bee/RailwayBuilderFactory.cs
+++ b/Zooper.Bee/RailwayBuilderFactory.cs
@@ -6,6 +6,7 @@ namespace Zooper.Bee;
 /// <summary>
 /// Provides factory methods for creating railways without requiring a request parameter.
 /// </summary>
+[Obsolete("Use Railway.Create() instead, which enforces a clear separation between the guard/validation phase and the step execution phase.")]
 public static class RailwayBuilderFactory
 {
 	/// <summary>

--- a/Zooper.Bee/RailwayFactory.cs
+++ b/Zooper.Bee/RailwayFactory.cs
@@ -1,0 +1,117 @@
+using System;
+using Zooper.Fox;
+
+namespace Zooper.Bee;
+
+/// <summary>
+/// Provides factory methods for creating railways using a two-phase builder pattern:
+/// a guard/validation phase followed by a step execution phase.
+/// </summary>
+public static class Railway
+{
+    /// <summary>
+    /// Creates a new railway with distinct guard and step phases.
+    /// </summary>
+    /// <typeparam name="TRequest">The type of the request input.</typeparam>
+    /// <typeparam name="TPayload">The type of the payload used to carry intermediate data.</typeparam>
+    /// <typeparam name="TSuccess">The type of the success result.</typeparam>
+    /// <typeparam name="TError">The type of the error result.</typeparam>
+    /// <param name="factory">
+    /// Factory function that takes a <typeparamref name="TRequest"/> and produces
+    /// the initial <typeparamref name="TPayload"/>.
+    /// </param>
+    /// <param name="selector">
+    /// Selector function that converts the final <typeparamref name="TPayload"/>
+    /// into a success result of type <typeparamref name="TSuccess"/>.
+    /// </param>
+    /// <param name="guards">
+    /// Optional action to configure guards and validations that run before any step.
+    /// Pass <see langword="null"/> when no guards are needed.
+    /// </param>
+    /// <param name="steps">
+    /// Action to configure the step execution phase.
+    /// </param>
+    /// <returns>A built <see cref="Railway{TRequest,TSuccess,TError}"/> ready for execution.</returns>
+    public static Railway<TRequest, TSuccess, TError> Create<TRequest, TPayload, TSuccess, TError>(
+        Func<TRequest, TPayload> factory,
+        Func<TPayload, TSuccess> selector,
+        Action<RailwayGuardBuilder<TRequest, TPayload, TSuccess, TError>>? guards,
+        Action<RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError>> steps)
+    {
+        var guardBuilder = new RailwayGuardBuilder<TRequest, TPayload, TSuccess, TError>();
+        guards?.Invoke(guardBuilder);
+
+        var stepsBuilder = new RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError>(
+            factory, selector, guardBuilder.Guards, guardBuilder.Validations);
+        steps(stepsBuilder);
+
+        return stepsBuilder.Build();
+    }
+
+    /// <summary>
+    /// Creates a new railway with only a step phase and no guards.
+    /// </summary>
+    /// <typeparam name="TRequest">The type of the request input.</typeparam>
+    /// <typeparam name="TPayload">The type of the payload used to carry intermediate data.</typeparam>
+    /// <typeparam name="TSuccess">The type of the success result.</typeparam>
+    /// <typeparam name="TError">The type of the error result.</typeparam>
+    /// <param name="factory">
+    /// Factory function that takes a <typeparamref name="TRequest"/> and produces
+    /// the initial <typeparamref name="TPayload"/>.
+    /// </param>
+    /// <param name="selector">
+    /// Selector function that converts the final <typeparamref name="TPayload"/>
+    /// into a success result of type <typeparamref name="TSuccess"/>.
+    /// </param>
+    /// <param name="steps">
+    /// Action to configure the step execution phase.
+    /// </param>
+    /// <returns>A built <see cref="Railway{TRequest,TSuccess,TError}"/> ready for execution.</returns>
+    public static Railway<TRequest, TSuccess, TError> Create<TRequest, TPayload, TSuccess, TError>(
+        Func<TRequest, TPayload> factory,
+        Func<TPayload, TSuccess> selector,
+        Action<RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError>> steps)
+    {
+        return Create(factory, selector, null, steps);
+    }
+
+    /// <summary>
+    /// Creates a new parameterless railway (no request input) with distinct guard and step phases.
+    /// </summary>
+    /// <typeparam name="TPayload">The type of the payload used to carry intermediate data.</typeparam>
+    /// <typeparam name="TSuccess">The type of the success result.</typeparam>
+    /// <typeparam name="TError">The type of the error result.</typeparam>
+    /// <param name="factory">Factory function that creates the initial payload.</param>
+    /// <param name="selector">Selector function that converts the final payload into a success result.</param>
+    /// <param name="guards">
+    /// Optional action to configure guards and validations that run before any step.
+    /// </param>
+    /// <param name="steps">Action to configure the step execution phase.</param>
+    /// <returns>A built <see cref="Railway{TRequest,TSuccess,TError}"/> ready for execution.</returns>
+    public static Railway<Unit, TSuccess, TError> Create<TPayload, TSuccess, TError>(
+        Func<TPayload> factory,
+        Func<TPayload, TSuccess> selector,
+        Action<RailwayGuardBuilder<Unit, TPayload, TSuccess, TError>>? guards,
+        Action<RailwayStepsBuilder<Unit, TPayload, TSuccess, TError>> steps)
+    {
+        return Create<Unit, TPayload, TSuccess, TError>(_ => factory(), selector, guards, steps);
+    }
+
+    /// <summary>
+    /// Creates a new parameterless railway (no request input) with only a step phase.
+    /// </summary>
+    /// <typeparam name="TPayload">The type of the payload used to carry intermediate data.</typeparam>
+    /// <typeparam name="TSuccess">The type of the success result.</typeparam>
+    /// <typeparam name="TError">The type of the error result.</typeparam>
+    /// <param name="factory">Factory function that creates the initial payload.</param>
+    /// <param name="selector">Selector function that converts the final payload into a success result.</param>
+    /// <param name="steps">Action to configure the step execution phase.</param>
+    /// <returns>A built <see cref="Railway{TRequest,TSuccess,TError}"/> ready for execution.</returns>
+    public static Railway<Unit, TSuccess, TError> Create<TPayload, TSuccess, TError>(
+        Func<TPayload> factory,
+        Func<TPayload, TSuccess> selector,
+        Action<RailwayStepsBuilder<Unit, TPayload, TSuccess, TError>> steps)
+    {
+        return Create(factory, selector, null, steps);
+    }
+}

--- a/Zooper.Bee/RailwayGuardBuilder.cs
+++ b/Zooper.Bee/RailwayGuardBuilder.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Zooper.Bee.Internal;
+using Zooper.Fox;
+
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace Zooper.Bee;
+
+/// <summary>
+/// Builds the guard and validation phase of a railway.
+/// Obtained via <see cref="Railway.Create{TRequest,TPayload,TSuccess,TError}(System.Func{TRequest,TPayload},System.Func{TPayload,TSuccess},System.Action{RailwayGuardBuilder{TRequest,TPayload,TSuccess,TError}},System.Action{RailwayStepsBuilder{TRequest,TPayload,TSuccess,TError}})"/>.
+/// Guards and validations registered here always execute before any step registered on
+/// <see cref="RailwayStepsBuilder{TRequest,TPayload,TSuccess,TError}"/>.
+/// </summary>
+/// <typeparam name="TRequest">The type of the request input.</typeparam>
+/// <typeparam name="TPayload">The type of the payload used to carry intermediate data.</typeparam>
+/// <typeparam name="TSuccess">The type of the success result.</typeparam>
+/// <typeparam name="TError">The type of the error result.</typeparam>
+public sealed class RailwayGuardBuilder<TRequest, TPayload, TSuccess, TError>
+{
+    internal List<RailwayGuard<TRequest, TError>> Guards { get; } = [];
+    internal List<RailwayValidation<TRequest, TError>> Validations { get; } = [];
+
+    internal RailwayGuardBuilder() { }
+
+    /// <summary>
+    /// Adds a guard to check if the railway can be executed.
+    /// If a guard fails, the railway will not execute and will return the error.
+    /// </summary>
+    /// <param name="guard">The guard function that returns Either an error or Unit</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayGuardBuilder<TRequest, TPayload, TSuccess, TError> Guard(
+        Func<TRequest, CancellationToken, Task<Either<TError, Unit>>> guard)
+    {
+        Guards.Add(new(guard));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a synchronous guard to check if the railway can be executed.
+    /// If a guard fails, the railway will not execute and will return the error.
+    /// </summary>
+    /// <param name="guard">The guard function that returns Either an error or Unit</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayGuardBuilder<TRequest, TPayload, TSuccess, TError> Guard(
+        Func<TRequest, Either<TError, Unit>> guard)
+    {
+        Guards.Add(new((request, _) => Task.FromResult(guard(request))));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a validation rule to the railway.
+    /// </summary>
+    /// <param name="validation">The validation function</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayGuardBuilder<TRequest, TPayload, TSuccess, TError> Validate(
+        Func<TRequest, CancellationToken, Task<Option<TError>>> validation)
+    {
+        Validations.Add(new(validation));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a synchronous validation rule to the railway.
+    /// </summary>
+    /// <param name="validation">The validation function</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayGuardBuilder<TRequest, TPayload, TSuccess, TError> Validate(
+        Func<TRequest, Option<TError>> validation)
+    {
+        Validations.Add(new((request, _) => Task.FromResult(validation(request))));
+        return this;
+    }
+}

--- a/Zooper.Bee/RailwayStepsBuilder.cs
+++ b/Zooper.Bee/RailwayStepsBuilder.cs
@@ -1,0 +1,522 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Zooper.Bee.Features;
+using Zooper.Bee.Internal;
+using Zooper.Bee.Internal.Executors;
+using Zooper.Fox;
+
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace Zooper.Bee;
+
+/// <summary>
+/// Builds the step execution phase of a railway.
+/// Obtained via <see cref="Railway.Create{TRequest,TPayload,TSuccess,TError}(System.Func{TRequest,TPayload},System.Func{TPayload,TSuccess},System.Action{RailwayGuardBuilder{TRequest,TPayload,TSuccess,TError}},System.Action{RailwayStepsBuilder{TRequest,TPayload,TSuccess,TError}})"/>.
+/// All steps are executed in registration order after the guard phase completes.
+/// </summary>
+/// <typeparam name="TRequest">The type of the request input.</typeparam>
+/// <typeparam name="TPayload">The type of the payload used to carry intermediate data.</typeparam>
+/// <typeparam name="TSuccess">The type of the success result.</typeparam>
+/// <typeparam name="TError">The type of the error result.</typeparam>
+public sealed class RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError>
+{
+    private readonly Func<TRequest, TPayload> _contextFactory;
+    private readonly Func<TPayload, TSuccess> _resultSelector;
+    private readonly List<RailwayGuard<TRequest, TError>> _guards;
+    private readonly List<RailwayValidation<TRequest, TError>> _validations;
+
+    private readonly List<Func<TPayload, CancellationToken, Task<Either<TError, TPayload>>>> _steps = [];
+    private readonly FeatureExecutorFactory<TPayload, TError> _featureExecutorFactory = new();
+    private readonly List<RailwayStep<TPayload, TError>> _finallyActivities = [];
+    private readonly List<Branch<TPayload, TError>> _branches = [];
+    private readonly List<object> _branchesWithLocalPayload = [];
+
+    internal RailwayStepsBuilder(
+        Func<TRequest, TPayload> contextFactory,
+        Func<TPayload, TSuccess> resultSelector,
+        List<RailwayGuard<TRequest, TError>> guards,
+        List<RailwayValidation<TRequest, TError>> validations)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+        _resultSelector = resultSelector ?? throw new ArgumentNullException(nameof(resultSelector));
+        _guards = guards;
+        _validations = validations;
+    }
+
+    /// <summary>
+    /// Adds an activity to the railway.
+    /// </summary>
+    /// <param name="activity">The activity function</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Do(
+        Func<TPayload, CancellationToken, Task<Either<TError, TPayload>>> activity)
+    {
+        _steps.Add(activity);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a synchronous activity to the railway.
+    /// </summary>
+    /// <param name="activity">The activity function</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Do(Func<TPayload, Either<TError, TPayload>> activity)
+    {
+        _steps.Add((payload, _) => Task.FromResult(activity(payload)));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds multiple activities to the railway.
+    /// </summary>
+    /// <param name="activities">The activity functions</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> DoAll(
+        params Func<TPayload, CancellationToken, Task<Either<TError, TPayload>>>[] activities)
+    {
+        foreach (var activity in activities)
+        {
+            _steps.Add(activity);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds multiple synchronous activities to the railway.
+    /// </summary>
+    /// <param name="activities">The activity functions</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> DoAll(
+        params Func<TPayload, Either<TError, TPayload>>[] activities)
+    {
+        foreach (var activity in activities)
+        {
+            _steps.Add((payload, _) => Task.FromResult(activity(payload)));
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a conditional activity to the railway that will only execute if the condition returns true.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate</param>
+    /// <param name="activity">The activity to execute if the condition is true</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> DoIf(
+        Func<TPayload, bool> condition,
+        Func<TPayload, CancellationToken, Task<Either<TError, TPayload>>> activity)
+    {
+        _steps.Add((payload, ct) =>
+            condition(payload)
+                ? activity(payload, ct)
+                : Task.FromResult(Either<TError, TPayload>.FromRight(payload)));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a synchronous conditional activity to the railway that will only execute if the condition returns true.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate</param>
+    /// <param name="activity">The activity to execute if the condition is true</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> DoIf(
+        Func<TPayload, bool> condition,
+        Func<TPayload, Either<TError, TPayload>> activity)
+    {
+        _steps.Add((payload, _) =>
+            Task.FromResult(condition(payload)
+                ? activity(payload)
+                : Either<TError, TPayload>.FromRight(payload)));
+        return this;
+    }
+
+    /// <summary>
+    /// Creates a group of activities in the railway with an optional condition.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate. If null, the group always executes.</param>
+    /// <param name="groupConfiguration">An action that configures the group</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Group(
+        Func<TPayload, bool>? condition,
+        Action<Features.Group.GroupBuilder<TRequest, TPayload, TSuccess, TError>> groupConfiguration)
+    {
+        var group = new Features.Group.Group<TPayload, TError>(condition);
+        var groupBuilder = new Features.Group.GroupBuilder<TRequest, TPayload, TSuccess, TError>(group);
+        groupConfiguration(groupBuilder);
+        _steps.Add((payload, ct) => ExecuteFeatureStepAsync(group, payload, ct));
+        return this;
+    }
+
+    /// <summary>
+    /// Creates a group of activities in the railway that always executes.
+    /// </summary>
+    /// <param name="groupConfiguration">An action that configures the group</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Group(
+        Action<Features.Group.GroupBuilder<TRequest, TPayload, TSuccess, TError>> groupConfiguration)
+    {
+        return Group(null, groupConfiguration);
+    }
+
+    /// <summary>
+    /// Creates a context with local state in the railway and an optional condition.
+    /// </summary>
+    /// <typeparam name="TLocalState">The type of the local context state</typeparam>
+    /// <param name="condition">The condition to evaluate. If null, the context always executes.</param>
+    /// <param name="localStateFactory">The factory function that creates the local state</param>
+    /// <param name="contextConfiguration">An action that configures the context</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> WithContext<TLocalState>(
+        Func<TPayload, bool>? condition,
+        Func<TPayload, TLocalState> localStateFactory,
+        Action<Features.Context.ContextBuilder<TRequest, TPayload, TLocalState, TSuccess, TError>> contextConfiguration)
+    {
+        var context = new Features.Context.Context<TPayload, TLocalState, TError>(condition, localStateFactory);
+        var contextBuilder = new Features.Context.ContextBuilder<TRequest, TPayload, TLocalState, TSuccess, TError>(context);
+        contextConfiguration(contextBuilder);
+        _steps.Add((payload, ct) => ExecuteFeatureStepAsync(context, payload, ct));
+        return this;
+    }
+
+    /// <summary>
+    /// Creates a context with local state in the railway that always executes.
+    /// </summary>
+    /// <typeparam name="TLocalState">The type of the local context state</typeparam>
+    /// <param name="localStateFactory">The factory function that creates the local state</param>
+    /// <param name="contextConfiguration">An action that configures the context</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> WithContext<TLocalState>(
+        Func<TPayload, TLocalState> localStateFactory,
+        Action<Features.Context.ContextBuilder<TRequest, TPayload, TLocalState, TSuccess, TError>> contextConfiguration)
+    {
+        return WithContext(null, localStateFactory, contextConfiguration);
+    }
+
+    /// <summary>
+    /// Creates a detached group of activities in the railway with an optional condition.
+    /// Detached groups don't merge their results back into the main railway.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate. If null, the detached group always executes.</param>
+    /// <param name="detachedConfiguration">An action that configures the detached group</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Detach(
+        Func<TPayload, bool>? condition,
+        Action<Features.Detached.DetachedBuilder<TRequest, TPayload, TSuccess, TError>> detachedConfiguration)
+    {
+        var detached = new Features.Detached.Detached<TPayload, TError>(condition);
+        var detachedBuilder = new Features.Detached.DetachedBuilder<TRequest, TPayload, TSuccess, TError>(detached);
+        detachedConfiguration(detachedBuilder);
+        _steps.Add((payload, ct) => ExecuteFeatureStepAsync(detached, payload, ct));
+        return this;
+    }
+
+    /// <summary>
+    /// Creates a detached group of activities in the railway that always executes.
+    /// Detached groups don't merge their results back into the main railway.
+    /// </summary>
+    /// <param name="detachedConfiguration">An action that configures the detached group</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Detach(
+        Action<Features.Detached.DetachedBuilder<TRequest, TPayload, TSuccess, TError>> detachedConfiguration)
+    {
+        return Detach(null, detachedConfiguration);
+    }
+
+    /// <summary>
+    /// Creates a parallel execution of multiple groups with an optional condition.
+    /// All groups execute in parallel, and their results are merged back into the main railway.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate. If null, the parallel execution always occurs.</param>
+    /// <param name="parallelConfiguration">An action that configures the parallel execution</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Parallel(
+        Func<TPayload, bool>? condition,
+        Action<Features.Parallel.ParallelBuilder<TRequest, TPayload, TSuccess, TError>> parallelConfiguration)
+    {
+        var parallel = new Features.Parallel.Parallel<TPayload, TError>(condition);
+        var parallelBuilder = new Features.Parallel.ParallelBuilder<TRequest, TPayload, TSuccess, TError>(parallel);
+        parallelConfiguration(parallelBuilder);
+        _steps.Add((payload, ct) => ExecuteFeatureStepAsync(parallel, payload, ct));
+        return this;
+    }
+
+    /// <summary>
+    /// Creates a parallel execution of multiple groups that always executes.
+    /// All groups execute in parallel, and their results are merged back into the main railway.
+    /// </summary>
+    /// <param name="parallelConfiguration">An action that configures the parallel execution</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Parallel(
+        Action<Features.Parallel.ParallelBuilder<TRequest, TPayload, TSuccess, TError>> parallelConfiguration)
+    {
+        return Parallel(null, parallelConfiguration);
+    }
+
+    /// <summary>
+    /// Creates a parallel execution of multiple detached groups with an optional condition.
+    /// All detached groups execute in parallel, and their results are NOT merged back.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate. If null, the parallel detached execution always occurs.</param>
+    /// <param name="parallelDetachedConfiguration">An action that configures the parallel detached execution</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> ParallelDetached(
+        Func<TPayload, bool>? condition,
+        Action<Features.Parallel.ParallelDetachedBuilder<TRequest, TPayload, TSuccess, TError>> parallelDetachedConfiguration)
+    {
+        var parallelDetached = new Features.Parallel.ParallelDetached<TPayload, TError>(condition);
+        var parallelDetachedBuilder =
+            new Features.Parallel.ParallelDetachedBuilder<TRequest, TPayload, TSuccess, TError>(parallelDetached);
+        parallelDetachedConfiguration(parallelDetachedBuilder);
+        _steps.Add((payload, ct) => ExecuteFeatureStepAsync(parallelDetached, payload, ct));
+        return this;
+    }
+
+    /// <summary>
+    /// Creates a parallel execution of multiple detached groups that always executes.
+    /// All detached groups execute in parallel, and their results are NOT merged back.
+    /// </summary>
+    /// <param name="parallelDetachedConfiguration">An action that configures the parallel detached execution</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> ParallelDetached(
+        Action<Features.Parallel.ParallelDetachedBuilder<TRequest, TPayload, TSuccess, TError>> parallelDetachedConfiguration)
+    {
+        return ParallelDetached(null, parallelDetachedConfiguration);
+    }
+
+    /// <summary>
+    /// Adds an activity to the "finally" block that will always execute, even if the railway fails.
+    /// </summary>
+    /// <param name="activity">The activity to execute</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Finally(
+        Func<TPayload, CancellationToken, Task<Either<TError, TPayload>>> activity)
+    {
+        _finallyActivities.Add(new(activity));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a synchronous activity to the "finally" block that will always execute, even if the railway fails.
+    /// </summary>
+    /// <param name="activity">The activity to execute</param>
+    /// <returns>The builder instance for method chaining</returns>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Finally(
+        Func<TPayload, Either<TError, TPayload>> activity)
+    {
+        _finallyActivities.Add(new((payload, _) => Task.FromResult(activity(payload))));
+        return this;
+    }
+
+    /// <summary>
+    /// Builds a railway that processes a request and returns either a success or an error.
+    /// </summary>
+    public Railway<TRequest, TSuccess, TError> Build()
+    {
+        return new(ExecuteRailwayAsync);
+    }
+
+    private async Task<Either<TError, TSuccess>> ExecuteRailwayAsync(
+        TRequest request,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await RunValidationsAsync(request, cancellationToken);
+        if (validationResult.IsLeft)
+            return Either<TError, TSuccess>.FromLeft(validationResult.Left!);
+
+        var guardResult = await RunGuardsAsync(request, cancellationToken);
+        if (guardResult.IsLeft)
+            return Either<TError, TSuccess>.FromLeft(guardResult.Left!);
+
+        var payload = _contextFactory(request);
+        if (payload == null)
+            return Either<TError, TSuccess>.FromRight(_resultSelector(default!));
+
+        try
+        {
+            var stepsResult = await RunStepsAsync(payload, cancellationToken);
+            if (stepsResult.IsLeft)
+                return Either<TError, TSuccess>.FromLeft(stepsResult.Left!);
+
+            payload = stepsResult.Right!;
+
+            var branchesResult = await RunBranchesAsync(payload, cancellationToken);
+            if (branchesResult.IsLeft)
+                return Either<TError, TSuccess>.FromLeft(branchesResult.Left!);
+
+            payload = branchesResult.Right!;
+
+            var branchLocalsResult = await RunBranchesWithLocalPayloadAsync(payload, cancellationToken);
+            if (branchLocalsResult.IsLeft)
+                return Either<TError, TSuccess>.FromLeft(branchLocalsResult.Left!);
+
+            payload = branchLocalsResult.Right!;
+
+            var successValue = _resultSelector(payload);
+            return Either<TError, TSuccess>.FromRight(successValue ?? default!);
+        }
+        finally
+        {
+            _ = await RunFinallyActivitiesAsync(payload, cancellationToken);
+        }
+    }
+
+    private async Task<Either<TError, TPayload>> RunValidationsAsync(
+        TRequest request,
+        CancellationToken cancellationToken)
+    {
+        foreach (var validation in _validations)
+        {
+            var validationOption = await validation.Validate(request, cancellationToken);
+            if (validationOption.IsSome && validationOption.Value != null)
+                return Either<TError, TPayload>.FromLeft(validationOption.Value);
+        }
+
+        return Either<TError, TPayload>.FromRight(default!);
+    }
+
+    private async Task<Either<TError, Unit>> RunGuardsAsync(
+        TRequest request,
+        CancellationToken cancellationToken)
+    {
+        foreach (var guard in _guards)
+        {
+            var result = await guard.Check(request, cancellationToken);
+            if (result.IsLeft && result.Left != null)
+                return Either<TError, Unit>.FromLeft(result.Left);
+        }
+
+        return Either<TError, Unit>.FromRight(Unit.Value);
+    }
+
+    private async Task<Either<TError, TPayload>> RunStepsAsync(
+        TPayload payload,
+        CancellationToken cancellationToken)
+    {
+        foreach (var step in _steps)
+        {
+            var result = await step(payload, cancellationToken);
+            if (result.IsLeft && result.Left != null)
+                return Either<TError, TPayload>.FromLeft(result.Left);
+
+            payload = result.Right!;
+        }
+
+        return Either<TError, TPayload>.FromRight(payload);
+    }
+
+    private async Task<Either<TError, TPayload>> ExecuteFeatureStepAsync(
+        IRailwayFeature<TPayload, TError> feature,
+        TPayload payload,
+        CancellationToken cancellationToken)
+    {
+        var result = await _featureExecutorFactory.ExecuteFeature(feature, payload, cancellationToken);
+        if (result.IsLeft && result.Left != null)
+            return Either<TError, TPayload>.FromLeft(result.Left);
+
+        return feature.ShouldMerge
+            ? Either<TError, TPayload>.FromRight(result.Right!)
+            : Either<TError, TPayload>.FromRight(payload);
+    }
+
+    private async Task<Either<TError, TPayload>> RunBranchesAsync(
+        TPayload payload,
+        CancellationToken cancellationToken)
+    {
+        foreach (var branch in _branches)
+        {
+            if (!branch.Condition(payload))
+                continue;
+
+            foreach (var activity in branch.Activities)
+            {
+                var result = await activity.Execute(payload, cancellationToken);
+                if (result.IsLeft && result.Left != null)
+                    return Either<TError, TPayload>.FromLeft(result.Left);
+
+                payload = result.Right!;
+            }
+        }
+
+        return Either<TError, TPayload>.FromRight(payload);
+    }
+
+    private async Task<Either<TError, TPayload>> RunBranchesWithLocalPayloadAsync(
+        TPayload payload,
+        CancellationToken cancellationToken)
+    {
+        foreach (var branchObject in _branchesWithLocalPayload)
+        {
+            var result = await ExecuteBranchWithLocalPayloadDynamic(branchObject, payload, cancellationToken);
+            if (result.IsLeft && result.Left != null)
+                return Either<TError, TPayload>.FromLeft(result.Left);
+
+            payload = result.Right!;
+        }
+
+        return Either<TError, TPayload>.FromRight(payload);
+    }
+
+    private async Task<TPayload> RunFinallyActivitiesAsync(
+        TPayload payload,
+        CancellationToken cancellationToken)
+    {
+        foreach (var finallyActivity in _finallyActivities)
+            _ = await finallyActivity.Execute(payload, cancellationToken);
+
+        return payload;
+    }
+
+    private async Task<Either<TError, TPayload>> ExecuteBranchWithLocalPayloadDynamic(
+        object branchObject,
+        TPayload payload,
+        CancellationToken cancellationToken)
+    {
+        var branchType = branchObject.GetType();
+
+        if (branchType.IsGenericType &&
+            branchType.GetGenericTypeDefinition() == typeof(BranchWithLocalPayload<,,>))
+        {
+            var methodInfo = typeof(RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError>)
+                .GetMethod(nameof(ExecuteBranchWithLocalPayload), BindingFlags.NonPublic | BindingFlags.Instance);
+            if (methodInfo == null)
+                throw new InvalidOperationException($"Method {nameof(ExecuteBranchWithLocalPayload)} not found.");
+
+            var localPayloadType = branchType.GetGenericArguments()[1];
+            var genericMethod = methodInfo.MakeGenericMethod(localPayloadType);
+            var task = (Task<Either<TError, TPayload>>)genericMethod.Invoke(
+                this,
+                [branchObject, payload, cancellationToken]
+            )!;
+            return await task.ConfigureAwait(false);
+        }
+
+        return Either<TError, TPayload>.FromRight(payload);
+    }
+
+    private async Task<Either<TError, TPayload>> ExecuteBranchWithLocalPayload<TLocalPayload>(
+        BranchWithLocalPayload<TPayload, TLocalPayload, TError> branch,
+        TPayload payload,
+        CancellationToken cancellationToken)
+    {
+        if (!branch.Condition(payload))
+            return Either<TError, TPayload>.FromRight(payload);
+
+        var localPayload = branch.LocalPayloadFactory(payload);
+
+        foreach (var activity in branch.Activities)
+        {
+            var result = await activity.Execute(payload, localPayload, cancellationToken);
+            if (result.IsLeft)
+                return Either<TError, TPayload>.FromLeft(result.Left);
+
+            (payload, localPayload) = result.Right;
+        }
+
+        return Either<TError, TPayload>.FromRight(payload);
+    }
+}


### PR DESCRIPTION
### Added

- **`Railway.Create()` — two-phase builder factory** that enforces a clear separation between the guard/validation phase and the step execution phase at the type-system level
  - `Railway.Create(factory, selector, guards, steps)` — with guards
  - `Railway.Create(factory, selector, steps)` — without guards (convenience overload)
  - Parameterless variants (`Func<TPayload>` factory) for railways with no request input
  - New `RailwayGuardBuilder<...>` — only exposes `Guard()` and `Validate()`
  - New `RailwayStepsBuilder<...>` — only exposes `Do()`, `DoIf()`, `DoAll()`, `Group()`, `WithContext()`, `Detach()`, `Parallel()`, `ParallelDetached()`, `Finally()`, and `Build()`

### Fixed

- **Registration-order bug**: `Group()`, `WithContext()`, `Detach()`, `Parallel()`, and `ParallelDetached()` steps now execute in the exact order they were registered, interleaved correctly with `Do()` steps. Previously all `Do()` steps ran before all feature steps regardless of registration order.

### Deprecated

- `RailwayBuilder<TRequest, TPayload, TSuccess, TError>` — use `Railway.Create()` instead
- `RailwayBuilderFactory` — use `Railway.Create()` instead