### PR TITLE
feat: add Loop operator for bounded iteration in railway DSL

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -35,7 +35,7 @@ Implement tasks from an OpenSpec change.
    ```
 
    This returns:
-   - Context file paths (varies by schema)
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
    - Progress (total, complete, remaining)
    - Task list with status
    - Dynamic instruction based on current state
@@ -47,7 +47,7 @@ Implement tasks from an OpenSpec change.
 
 4. **Read context files**
 
-   Read the files listed in `contextFiles` from the apply instructions output.
+   Read every file path listed under `contextFiles` from the apply instructions output.
    The files depend on the schema being used:
    - **spec-driven**: proposal, specs, design, tasks
    - Other schemas: follow the contextFiles from CLI output

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -59,7 +59,7 @@ Archive a completed change in the experimental workflow.
    - If changes needed: "Sync now (recommended)", "Archive without syncing"
    - If already synced: "Archive now", "Sync anyway", "Cancel"
 
-   If user chooses sync, execute `/opsx:sync` logic. Proceed to archive regardless of choice.
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
 5. **Perform the archive**
 
@@ -153,5 +153,5 @@ Target archive directory already exists.
 - Don't block archive on warnings - just inform and confirm
 - Preserve .openspec.yaml when moving to archive (it moves with the directory)
 - Show clear summary of what happened
-- If sync is requested, use /opsx:sync approach (agent-driven)
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
 - If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/bulk-archive.md
+++ b/.claude/commands/opsx/bulk-archive.md
@@ -80,7 +80,7 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    Display a table summarizing all changes:
 
    ```
-   | Change               | Artifacts | Tasks | Specs   | Conflicts | Status |
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
    |---------------------|-----------|-------|---------|-----------|--------|
    | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
    | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
@@ -225,7 +225,7 @@ Failed K changes:
 ```
 ## No Changes to Archive
 
-No active changes found. Use `/opsx:new` to create a new change.
+No active changes found. Create a new change to get started.
 ```
 
 **Guardrails**

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -7,7 +7,7 @@ tags: [workflow, explore, experimental, thinking]
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
 
-**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first (e.g., start a change with `/opsx:new` or `/opsx:ff`). You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
 
 **This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
 
@@ -59,10 +59,10 @@ Depending on what the user brings, you might:
 │     Use ASCII diagrams liberally        │
 ├─────────────────────────────────────────┤
 │                                         │
-│   ┌────────┐         ┌────────┐        │
-│   │ State  │────────▶│ State  │        │
-│   │   A    │         │   B    │        │
-│   └────────┘         └────────┘        │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
 │                                         │
 │   System diagrams, state machines,      │
 │   data flows, architecture sketches,    │
@@ -100,8 +100,7 @@ If the user mentioned a specific change name, read its artifacts for context.
 
 Think freely. When insights crystallize, you might offer:
 
-- "This feels solid enough to start a change. Want me to create one?"
-  → Can transition to `/opsx:new` or `/opsx:ff`
+- "This feels solid enough to start a change. Want me to create a proposal?"
 - Or keep exploring - no pressure to formalize
 
 ### When a change exists
@@ -120,14 +119,14 @@ If the user mentions a change or you detect one is relevant:
 
 3. **Offer to capture when decisions are made**
 
-   | Insight Type | Where to Capture |
-   |--------------|------------------|
-   | New requirement discovered | `specs/<capability>/spec.md` |
-   | Requirement changed | `specs/<capability>/spec.md` |
-   | Design decision made | `design.md` |
-   | Scope changed | `proposal.md` |
-   | New work identified | `tasks.md` |
-   | Assumption invalidated | Relevant artifact |
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
 
    Example offers:
    - "That's a design decision. Capture it in design.md?"
@@ -153,7 +152,7 @@ If the user mentions a change or you detect one is relevant:
 
 There's no required ending. Discovery might:
 
-- **Flow into action**: "Ready to start? `/opsx:new` or `/opsx:ff`"
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
 - **Result in artifact updates**: "Updated design.md with these decisions"
 - **Just provide clarity**: User has what they need, moves on
 - **Continue later**: "We can pick this up anytime"

--- a/.claude/commands/opsx/ff.md
+++ b/.claude/commands/opsx/ff.md
@@ -84,7 +84,10 @@ After completing all artifacts, summarize:
 - Follow the `instruction` field from `openspec instructions` for each artifact type
 - The schema defines what each artifact should contain - follow it
 - Read dependency artifacts for context before creating new ones
-- Use the `template` as a starting point, filling in based on context
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
 
 **Guardrails**
 - Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)

--- a/.claude/commands/opsx/onboard.md
+++ b/.claude/commands/opsx/onboard.md
@@ -11,16 +11,19 @@ Guide the user through their first complete OpenSpec workflow cycle. This is a t
 
 ## Preflight
 
-Before starting, check if OpenSpec is initialized:
+Before starting, check if the OpenSpec CLI is installed:
 
 ```bash
-openspec status --json 2>&1 || echo "NOT_INITIALIZED"
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
 ```
 
-**If not initialized:**
-> OpenSpec isn't set up in this project yet. Run `openspec init` first, then come back to `/opsx:onboard`.
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
 
-Stop here if not initialized.
+Stop here if not installed.
 
 ---
 
@@ -63,7 +66,10 @@ Scan the codebase for small improvement opportunities. Look for:
 
 Also check recent git activity:
 ```bash
+# Unix/macOS
 git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
 ```
 
 ### Present Suggestions
@@ -258,7 +264,10 @@ For a small task like this, we might only need one spec file.
 
 **DO:** Create the spec file:
 ```bash
+# Unix/macOS
 mkdir -p openspec/changes/<name>/specs/<capability-name>
+# Windows (PowerShell)
+# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
 ```
 
 Draft the spec content:
@@ -453,21 +462,29 @@ This same rhythm works for any size change—a small fix or a major feature.
 
 ## Command Reference
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:explore` | Think through problems before/during work |
-| `/opsx:new` | Start a new change, step through artifacts |
-| `/opsx:ff` | Fast-forward: create all artifacts at once |
-| `/opsx:continue` | Continue working on an existing change |
-| `/opsx:apply` | Implement tasks from a change |
-| `/opsx:verify` | Verify implementation matches artifacts |
-| `/opsx:archive` | Archive a completed change |
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
 
 ---
 
 ## What's Next?
 
-Try `/opsx:new` or `/opsx:ff` on something you actually want to build. You've got the rhythm now!
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
 ```
 
 ---
@@ -497,17 +514,25 @@ If the user says they just want to see the commands or skip the tutorial:
 ```
 ## OpenSpec Quick Reference
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:explore` | Think through problems (no code changes) |
-| `/opsx:new <name>` | Start a new change, step by step |
-| `/opsx:ff <name>` | Fast-forward: all artifacts at once |
-| `/opsx:continue <name>` | Continue an existing change |
-| `/opsx:apply <name>` | Implement tasks |
-| `/opsx:verify <name>` | Verify implementation |
-| `/opsx:archive <name>` | Archive when done |
+**Core workflow:**
 
-Try `/opsx:new` to start your first change, or `/opsx:ff` if you want to move fast.
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
 ```
 
 Exit gracefully.

--- a/.claude/commands/opsx/verify.md
+++ b/.claude/commands/opsx/verify.md
@@ -35,7 +35,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    openspec instructions apply --change "<name>" --json
    ```
 
-   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+   This returns the change directory and `contextFiles` (artifact ID -> array of concrete file paths). Read all available artifacts from `contextFiles`.
 
 4. **Initialize verification report structure**
 
@@ -49,7 +49,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 5. **Verify Completeness**
 
    **Task Completion**:
-   - If tasks.md exists in contextFiles, read it
+   - If `contextFiles.tasks` exists, read every file path in it
    - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
    - Count complete vs total tasks
    - If incomplete tasks exist:
@@ -88,7 +88,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 7. **Verify Coherence**
 
    **Design Adherence**:
-   - If design.md exists in contextFiles:
+   - If `contextFiles.design` exists:
      - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
      - Verify implementation follows those decisions
      - If contradiction detected:

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Implement tasks from an OpenSpec change.
@@ -39,7 +39,7 @@ Implement tasks from an OpenSpec change.
    ```
 
    This returns:
-   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
    - Progress (total, complete, remaining)
    - Task list with status
    - Dynamic instruction based on current state
@@ -51,7 +51,7 @@ Implement tasks from an OpenSpec change.
 
 4. **Read context files**
 
-   Read the files listed in `contextFiles` from the apply instructions output.
+   Read every file path listed under `contextFiles` from the apply instructions output.
    The files depend on the schema being used:
    - **spec-driven**: proposal, specs, design, tasks
    - Other schemas: follow the contextFiles from CLI output

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Archive a completed change in the experimental workflow.
@@ -63,7 +63,7 @@ Archive a completed change in the experimental workflow.
    - If changes needed: "Sync now (recommended)", "Archive without syncing"
    - If already synced: "Archive now", "Sync anyway", "Cancel"
 
-   If user chooses sync, execute /opsx:sync logic (use the openspec-sync-specs skill). Proceed to archive regardless of choice.
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
 5. **Perform the archive**
 

--- a/.claude/skills/openspec-bulk-archive-change/SKILL.md
+++ b/.claude/skills/openspec-bulk-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Archive multiple completed changes in a single operation.
@@ -84,7 +84,7 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    Display a table summarizing all changes:
 
    ```
-   | Change               | Artifacts | Tasks | Specs   | Conflicts | Status |
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
    |---------------------|-----------|-------|---------|-----------|--------|
    | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
    | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
@@ -229,7 +229,7 @@ Failed K changes:
 ```
 ## No Changes to Archive
 
-No active changes found. Use `/opsx:new` to create a new change.
+No active changes found. Create a new change to get started.
 ```
 
 **Guardrails**

--- a/.claude/skills/openspec-continue-change/SKILL.md
+++ b/.claude/skills/openspec-continue-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Continue working on a change by creating the next artifact.

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -6,12 +6,12 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
 
-**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first (e.g., start a change with `/opsx:new` or `/opsx:ff`). You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
 
 **This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
 
@@ -56,10 +56,10 @@ Depending on what the user brings, you might:
 │     Use ASCII diagrams liberally        │
 ├─────────────────────────────────────────┤
 │                                         │
-│   ┌────────┐         ┌────────┐        │
-│   │ State  │────────▶│ State  │        │
-│   │   A    │         │   B    │        │
-│   └────────┘         └────────┘        │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
 │                                         │
 │   System diagrams, state machines,      │
 │   data flows, architecture sketches,    │
@@ -95,8 +95,7 @@ This tells you:
 
 Think freely. When insights crystallize, you might offer:
 
-- "This feels solid enough to start a change. Want me to create one?"
-  → Can transition to `/opsx:new` or `/opsx:ff`
+- "This feels solid enough to start a change. Want me to create a proposal?"
 - Or keep exploring - no pressure to formalize
 
 ### When a change exists
@@ -115,14 +114,14 @@ If the user mentions a change or you detect one is relevant:
 
 3. **Offer to capture when decisions are made**
 
-   | Insight Type | Where to Capture |
-   |--------------|------------------|
-   | New requirement discovered | `specs/<capability>/spec.md` |
-   | Requirement changed | `specs/<capability>/spec.md` |
-   | Design decision made | `design.md` |
-   | Scope changed | `proposal.md` |
-   | New work identified | `tasks.md` |
-   | Assumption invalidated | Relevant artifact |
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
 
    Example offers:
    - "That's a design decision. Capture it in design.md?"
@@ -228,7 +227,7 @@ User: A CLI tool that tracks local dev environments
 You: That changes everything.
 
      ┌─────────────────────────────────────────────────┐
-     │         CLI TOOL DATA STORAGE                  │
+     │          CLI TOOL DATA STORAGE                  │
      └─────────────────────────────────────────────────┘
 
      Key constraints:
@@ -252,7 +251,7 @@ You: That changes everything.
 
 There's no required ending. Discovery might:
 
-- **Flow into action**: "Ready to start? /opsx:new or /opsx:ff"
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
 - **Result in artifact updates**: "Updated design.md with these decisions"
 - **Just provide clarity**: User has what they need, moves on
 - **Continue later**: "We can pick this up anytime"
@@ -269,8 +268,7 @@ When it feels like things are crystallizing, you might summarize:
 **Open questions**: [if any remain]
 
 **Next steps** (if ready):
-- Create a change: /opsx:new <name>
-- Fast-forward to tasks: /opsx:ff <name>
+- Create a change proposal
 - Keep exploring: just keep talking
 ```
 

--- a/.claude/skills/openspec-ff-change/SKILL.md
+++ b/.claude/skills/openspec-ff-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Fast-forward through artifact creation - generate everything needed to start implementation in one go.

--- a/.claude/skills/openspec-new-change/SKILL.md
+++ b/.claude/skills/openspec-new-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Start a new change using the experimental artifact-driven approach.

--- a/.claude/skills/openspec-onboard/SKILL.md
+++ b/.claude/skills/openspec-onboard/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
@@ -15,16 +15,19 @@ Guide the user through their first complete OpenSpec workflow cycle. This is a t
 
 ## Preflight
 
-Before starting, check if OpenSpec is initialized:
+Before starting, check if the OpenSpec CLI is installed:
 
 ```bash
-openspec status --json 2>&1 || echo "NOT_INITIALIZED"
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
 ```
 
-**If not initialized:**
-> OpenSpec isn't set up in this project yet. Run `openspec init` first, then come back to `/opsx:onboard`.
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
 
-Stop here if not initialized.
+Stop here if not installed.
 
 ---
 
@@ -67,7 +70,10 @@ Scan the codebase for small improvement opportunities. Look for:
 
 Also check recent git activity:
 ```bash
+# Unix/macOS
 git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
 ```
 
 ### Present Suggestions
@@ -262,7 +268,10 @@ For a small task like this, we might only need one spec file.
 
 **DO:** Create the spec file:
 ```bash
+# Unix/macOS
 mkdir -p openspec/changes/<name>/specs/<capability-name>
+# Windows (PowerShell)
+# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
 ```
 
 Draft the spec content:
@@ -457,21 +466,29 @@ This same rhythm works for any size change—a small fix or a major feature.
 
 ## Command Reference
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:explore` | Think through problems before/during work |
-| `/opsx:new` | Start a new change, step through artifacts |
-| `/opsx:ff` | Fast-forward: create all artifacts at once |
-| `/opsx:continue` | Continue working on an existing change |
-| `/opsx:apply` | Implement tasks from a change |
-| `/opsx:verify` | Verify implementation matches artifacts |
-| `/opsx:archive` | Archive a completed change |
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
 
 ---
 
 ## What's Next?
 
-Try `/opsx:new` or `/opsx:ff` on something you actually want to build. You've got the rhythm now!
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
 ```
 
 ---
@@ -501,17 +518,25 @@ If the user says they just want to see the commands or skip the tutorial:
 ```
 ## OpenSpec Quick Reference
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:explore` | Think through problems (no code changes) |
-| `/opsx:new <name>` | Start a new change, step by step |
-| `/opsx:ff <name>` | Fast-forward: all artifacts at once |
-| `/opsx:continue <name>` | Continue an existing change |
-| `/opsx:apply <name>` | Implement tasks |
-| `/opsx:verify <name>` | Verify implementation |
-| `/opsx:archive <name>` | Archive when done |
+**Core workflow:**
 
-Try `/opsx:new` to start your first change, or `/opsx:ff` if you want to move fast.
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
 ```
 
 Exit gracefully.

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Sync delta specs from a change to main specs.

--- a/.claude/skills/openspec-verify-change/SKILL.md
+++ b/.claude/skills/openspec-verify-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Verify that an implementation matches the change artifacts (specs, tasks, design).
@@ -39,7 +39,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    openspec instructions apply --change "<name>" --json
    ```
 
-   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+   This returns the change directory and `contextFiles` (artifact ID -> array of concrete file paths). Read all available artifacts from `contextFiles`.
 
 4. **Initialize verification report structure**
 
@@ -53,7 +53,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 5. **Verify Completeness**
 
    **Task Completion**:
-   - If tasks.md exists in contextFiles, read it
+   - If `contextFiles.tasks` exists, read every file path in it
    - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
    - Count complete vs total tasks
    - If incomplete tasks exist:
@@ -92,7 +92,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 7. **Verify Coherence**
 
    **Design Adherence**:
-   - If design.md exists in contextFiles:
+   - If `contextFiles.design` exists:
      - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
      - Verify implementation follows those decisions
      - If contradiction detected:

--- a/.github/prompts/opsx-apply.prompt.md
+++ b/.github/prompts/opsx-apply.prompt.md
@@ -32,7 +32,7 @@ Implement tasks from an OpenSpec change.
    ```
 
    This returns:
-   - Context file paths (varies by schema)
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
    - Progress (total, complete, remaining)
    - Task list with status
    - Dynamic instruction based on current state
@@ -44,7 +44,7 @@ Implement tasks from an OpenSpec change.
 
 4. **Read context files**
 
-   Read the files listed in `contextFiles` from the apply instructions output.
+   Read every file path listed under `contextFiles` from the apply instructions output.
    The files depend on the schema being used:
    - **spec-driven**: proposal, specs, design, tasks
    - Other schemas: follow the contextFiles from CLI output

--- a/.github/prompts/opsx-archive.prompt.md
+++ b/.github/prompts/opsx-archive.prompt.md
@@ -56,7 +56,7 @@ Archive a completed change in the experimental workflow.
    - If changes needed: "Sync now (recommended)", "Archive without syncing"
    - If already synced: "Archive now", "Sync anyway", "Cancel"
 
-   If user chooses sync, execute `/opsx:sync` logic. Proceed to archive regardless of choice.
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
 5. **Perform the archive**
 
@@ -150,5 +150,5 @@ Target archive directory already exists.
 - Don't block archive on warnings - just inform and confirm
 - Preserve .openspec.yaml when moving to archive (it moves with the directory)
 - Show clear summary of what happened
-- If sync is requested, use /opsx:sync approach (agent-driven)
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
 - If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/prompts/opsx-bulk-archive.prompt.md
+++ b/.github/prompts/opsx-bulk-archive.prompt.md
@@ -77,7 +77,7 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    Display a table summarizing all changes:
 
    ```
-   | Change               | Artifacts | Tasks | Specs   | Conflicts | Status |
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
    |---------------------|-----------|-------|---------|-----------|--------|
    | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
    | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
@@ -222,7 +222,7 @@ Failed K changes:
 ```
 ## No Changes to Archive
 
-No active changes found. Use `/opsx:new` to create a new change.
+No active changes found. Create a new change to get started.
 ```
 
 **Guardrails**

--- a/.github/prompts/opsx-explore.prompt.md
+++ b/.github/prompts/opsx-explore.prompt.md
@@ -4,7 +4,7 @@ description: Enter explore mode - think through ideas, investigate problems, cla
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
 
-**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first (e.g., start a change with `/opsx:new` or `/opsx:ff`). You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
 
 **This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
 
@@ -56,10 +56,10 @@ Depending on what the user brings, you might:
 │     Use ASCII diagrams liberally        │
 ├─────────────────────────────────────────┤
 │                                         │
-│   ┌────────┐         ┌────────┐        │
-│   │ State  │────────▶│ State  │        │
-│   │   A    │         │   B    │        │
-│   └────────┘         └────────┘        │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
 │                                         │
 │   System diagrams, state machines,      │
 │   data flows, architecture sketches,    │
@@ -97,8 +97,7 @@ If the user mentioned a specific change name, read its artifacts for context.
 
 Think freely. When insights crystallize, you might offer:
 
-- "This feels solid enough to start a change. Want me to create one?"
-  → Can transition to `/opsx:new` or `/opsx:ff`
+- "This feels solid enough to start a change. Want me to create a proposal?"
 - Or keep exploring - no pressure to formalize
 
 ### When a change exists
@@ -117,14 +116,14 @@ If the user mentions a change or you detect one is relevant:
 
 3. **Offer to capture when decisions are made**
 
-   | Insight Type | Where to Capture |
-   |--------------|------------------|
-   | New requirement discovered | `specs/<capability>/spec.md` |
-   | Requirement changed | `specs/<capability>/spec.md` |
-   | Design decision made | `design.md` |
-   | Scope changed | `proposal.md` |
-   | New work identified | `tasks.md` |
-   | Assumption invalidated | Relevant artifact |
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
 
    Example offers:
    - "That's a design decision. Capture it in design.md?"
@@ -150,7 +149,7 @@ If the user mentions a change or you detect one is relevant:
 
 There's no required ending. Discovery might:
 
-- **Flow into action**: "Ready to start? `/opsx:new` or `/opsx:ff`"
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
 - **Result in artifact updates**: "Updated design.md with these decisions"
 - **Just provide clarity**: User has what they need, moves on
 - **Continue later**: "We can pick this up anytime"

--- a/.github/prompts/opsx-ff.prompt.md
+++ b/.github/prompts/opsx-ff.prompt.md
@@ -81,7 +81,10 @@ After completing all artifacts, summarize:
 - Follow the `instruction` field from `openspec instructions` for each artifact type
 - The schema defines what each artifact should contain - follow it
 - Read dependency artifacts for context before creating new ones
-- Use the `template` as a starting point, filling in based on context
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
 
 **Guardrails**
 - Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)

--- a/.github/prompts/opsx-onboard.prompt.md
+++ b/.github/prompts/opsx-onboard.prompt.md
@@ -8,16 +8,19 @@ Guide the user through their first complete OpenSpec workflow cycle. This is a t
 
 ## Preflight
 
-Before starting, check if OpenSpec is initialized:
+Before starting, check if the OpenSpec CLI is installed:
 
 ```bash
-openspec status --json 2>&1 || echo "NOT_INITIALIZED"
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
 ```
 
-**If not initialized:**
-> OpenSpec isn't set up in this project yet. Run `openspec init` first, then come back to `/opsx:onboard`.
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
 
-Stop here if not initialized.
+Stop here if not installed.
 
 ---
 
@@ -60,7 +63,10 @@ Scan the codebase for small improvement opportunities. Look for:
 
 Also check recent git activity:
 ```bash
+# Unix/macOS
 git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
 ```
 
 ### Present Suggestions
@@ -255,7 +261,10 @@ For a small task like this, we might only need one spec file.
 
 **DO:** Create the spec file:
 ```bash
+# Unix/macOS
 mkdir -p openspec/changes/<name>/specs/<capability-name>
+# Windows (PowerShell)
+# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
 ```
 
 Draft the spec content:
@@ -450,21 +459,29 @@ This same rhythm works for any size change—a small fix or a major feature.
 
 ## Command Reference
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:explore` | Think through problems before/during work |
-| `/opsx:new` | Start a new change, step through artifacts |
-| `/opsx:ff` | Fast-forward: create all artifacts at once |
-| `/opsx:continue` | Continue working on an existing change |
-| `/opsx:apply` | Implement tasks from a change |
-| `/opsx:verify` | Verify implementation matches artifacts |
-| `/opsx:archive` | Archive a completed change |
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
 
 ---
 
 ## What's Next?
 
-Try `/opsx:new` or `/opsx:ff` on something you actually want to build. You've got the rhythm now!
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
 ```
 
 ---
@@ -494,17 +511,25 @@ If the user says they just want to see the commands or skip the tutorial:
 ```
 ## OpenSpec Quick Reference
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:explore` | Think through problems (no code changes) |
-| `/opsx:new <name>` | Start a new change, step by step |
-| `/opsx:ff <name>` | Fast-forward: all artifacts at once |
-| `/opsx:continue <name>` | Continue an existing change |
-| `/opsx:apply <name>` | Implement tasks |
-| `/opsx:verify <name>` | Verify implementation |
-| `/opsx:archive <name>` | Archive when done |
+**Core workflow:**
 
-Try `/opsx:new` to start your first change, or `/opsx:ff` if you want to move fast.
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
 ```
 
 Exit gracefully.

--- a/.github/prompts/opsx-verify.prompt.md
+++ b/.github/prompts/opsx-verify.prompt.md
@@ -32,7 +32,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    openspec instructions apply --change "<name>" --json
    ```
 
-   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+   This returns the change directory and `contextFiles` (artifact ID -> array of concrete file paths). Read all available artifacts from `contextFiles`.
 
 4. **Initialize verification report structure**
 
@@ -46,7 +46,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 5. **Verify Completeness**
 
    **Task Completion**:
-   - If tasks.md exists in contextFiles, read it
+   - If `contextFiles.tasks` exists, read every file path in it
    - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
    - Count complete vs total tasks
    - If incomplete tasks exist:
@@ -85,7 +85,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 7. **Verify Coherence**
 
    **Design Adherence**:
-   - If design.md exists in contextFiles:
+   - If `contextFiles.design` exists:
      - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
      - Verify implementation follows those decisions
      - If contradiction detected:

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Implement tasks from an OpenSpec change.
@@ -39,7 +39,7 @@ Implement tasks from an OpenSpec change.
    ```
 
    This returns:
-   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
    - Progress (total, complete, remaining)
    - Task list with status
    - Dynamic instruction based on current state
@@ -51,7 +51,7 @@ Implement tasks from an OpenSpec change.
 
 4. **Read context files**
 
-   Read the files listed in `contextFiles` from the apply instructions output.
+   Read every file path listed under `contextFiles` from the apply instructions output.
    The files depend on the schema being used:
    - **spec-driven**: proposal, specs, design, tasks
    - Other schemas: follow the contextFiles from CLI output

--- a/.github/skills/openspec-archive-change/SKILL.md
+++ b/.github/skills/openspec-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Archive a completed change in the experimental workflow.
@@ -63,7 +63,7 @@ Archive a completed change in the experimental workflow.
    - If changes needed: "Sync now (recommended)", "Archive without syncing"
    - If already synced: "Archive now", "Sync anyway", "Cancel"
 
-   If user chooses sync, execute /opsx:sync logic (use the openspec-sync-specs skill). Proceed to archive regardless of choice.
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
 5. **Perform the archive**
 

--- a/.github/skills/openspec-bulk-archive-change/SKILL.md
+++ b/.github/skills/openspec-bulk-archive-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Archive multiple completed changes in a single operation.
@@ -84,7 +84,7 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
    Display a table summarizing all changes:
 
    ```
-   | Change               | Artifacts | Tasks | Specs   | Conflicts | Status |
+   | Change              | Artifacts | Tasks | Specs   | Conflicts | Status |
    |---------------------|-----------|-------|---------|-----------|--------|
    | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
    | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
@@ -229,7 +229,7 @@ Failed K changes:
 ```
 ## No Changes to Archive
 
-No active changes found. Use `/opsx:new` to create a new change.
+No active changes found. Create a new change to get started.
 ```
 
 **Guardrails**

--- a/.github/skills/openspec-continue-change/SKILL.md
+++ b/.github/skills/openspec-continue-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Continue working on a change by creating the next artifact.

--- a/.github/skills/openspec-explore/SKILL.md
+++ b/.github/skills/openspec-explore/SKILL.md
@@ -6,12 +6,12 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
 
-**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first (e.g., start a change with `/opsx:new` or `/opsx:ff`). You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
 
 **This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
 
@@ -56,10 +56,10 @@ Depending on what the user brings, you might:
 │     Use ASCII diagrams liberally        │
 ├─────────────────────────────────────────┤
 │                                         │
-│   ┌────────┐         ┌────────┐        │
-│   │ State  │────────▶│ State  │        │
-│   │   A    │         │   B    │        │
-│   └────────┘         └────────┘        │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
 │                                         │
 │   System diagrams, state machines,      │
 │   data flows, architecture sketches,    │
@@ -95,8 +95,7 @@ This tells you:
 
 Think freely. When insights crystallize, you might offer:
 
-- "This feels solid enough to start a change. Want me to create one?"
-  → Can transition to `/opsx:new` or `/opsx:ff`
+- "This feels solid enough to start a change. Want me to create a proposal?"
 - Or keep exploring - no pressure to formalize
 
 ### When a change exists
@@ -115,14 +114,14 @@ If the user mentions a change or you detect one is relevant:
 
 3. **Offer to capture when decisions are made**
 
-   | Insight Type | Where to Capture |
-   |--------------|------------------|
-   | New requirement discovered | `specs/<capability>/spec.md` |
-   | Requirement changed | `specs/<capability>/spec.md` |
-   | Design decision made | `design.md` |
-   | Scope changed | `proposal.md` |
-   | New work identified | `tasks.md` |
-   | Assumption invalidated | Relevant artifact |
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
 
    Example offers:
    - "That's a design decision. Capture it in design.md?"
@@ -228,7 +227,7 @@ User: A CLI tool that tracks local dev environments
 You: That changes everything.
 
      ┌─────────────────────────────────────────────────┐
-     │         CLI TOOL DATA STORAGE                  │
+     │          CLI TOOL DATA STORAGE                  │
      └─────────────────────────────────────────────────┘
 
      Key constraints:
@@ -252,7 +251,7 @@ You: That changes everything.
 
 There's no required ending. Discovery might:
 
-- **Flow into action**: "Ready to start? /opsx:new or /opsx:ff"
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
 - **Result in artifact updates**: "Updated design.md with these decisions"
 - **Just provide clarity**: User has what they need, moves on
 - **Continue later**: "We can pick this up anytime"
@@ -269,8 +268,7 @@ When it feels like things are crystallizing, you might summarize:
 **Open questions**: [if any remain]
 
 **Next steps** (if ready):
-- Create a change: /opsx:new <name>
-- Fast-forward to tasks: /opsx:ff <name>
+- Create a change proposal
 - Keep exploring: just keep talking
 ```
 

--- a/.github/skills/openspec-ff-change/SKILL.md
+++ b/.github/skills/openspec-ff-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Fast-forward through artifact creation - generate everything needed to start implementation in one go.

--- a/.github/skills/openspec-new-change/SKILL.md
+++ b/.github/skills/openspec-new-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Start a new change using the experimental artifact-driven approach.

--- a/.github/skills/openspec-onboard/SKILL.md
+++ b/.github/skills/openspec-onboard/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
@@ -15,16 +15,19 @@ Guide the user through their first complete OpenSpec workflow cycle. This is a t
 
 ## Preflight
 
-Before starting, check if OpenSpec is initialized:
+Before starting, check if the OpenSpec CLI is installed:
 
 ```bash
-openspec status --json 2>&1 || echo "NOT_INITIALIZED"
+# Unix/macOS
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
+# Windows (PowerShell)
+# if (Get-Command openspec -ErrorAction SilentlyContinue) { openspec --version } else { echo "CLI_NOT_INSTALLED" }
 ```
 
-**If not initialized:**
-> OpenSpec isn't set up in this project yet. Run `openspec init` first, then come back to `/opsx:onboard`.
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to `/opsx:onboard`.
 
-Stop here if not initialized.
+Stop here if not installed.
 
 ---
 
@@ -67,7 +70,10 @@ Scan the codebase for small improvement opportunities. Look for:
 
 Also check recent git activity:
 ```bash
+# Unix/macOS
 git log --oneline -10 2>/dev/null || echo "No git history"
+# Windows (PowerShell)
+# git log --oneline -10 2>$null; if ($LASTEXITCODE -ne 0) { echo "No git history" }
 ```
 
 ### Present Suggestions
@@ -262,7 +268,10 @@ For a small task like this, we might only need one spec file.
 
 **DO:** Create the spec file:
 ```bash
+# Unix/macOS
 mkdir -p openspec/changes/<name>/specs/<capability-name>
+# Windows (PowerShell)
+# New-Item -ItemType Directory -Force -Path "openspec/changes/<name>/specs/<capability-name>"
 ```
 
 Draft the spec content:
@@ -457,21 +466,29 @@ This same rhythm works for any size change—a small fix or a major feature.
 
 ## Command Reference
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:explore` | Think through problems before/during work |
-| `/opsx:new` | Start a new change, step through artifacts |
-| `/opsx:ff` | Fast-forward: create all artifacts at once |
-| `/opsx:continue` | Continue working on an existing change |
-| `/opsx:apply` | Implement tasks from a change |
-| `/opsx:verify` | Verify implementation matches artifacts |
-| `/opsx:archive` | Archive a completed change |
+**Core workflow:**
+
+ | Command           | What it does                               |
+ |-------------------|--------------------------------------------|
+ | `/opsx:propose` | Create a change and generate all artifacts |
+ | `/opsx:explore` | Think through problems before/during work  |
+ | `/opsx:apply`   | Implement tasks from a change              |
+ | `/opsx:archive` | Archive a completed change                 |
+
+**Additional commands:**
+
+ | Command            | What it does                                             |
+ |--------------------|----------------------------------------------------------|
+ | `/opsx:new`      | Start a new change, step through artifacts one at a time |
+ | `/opsx:continue` | Continue working on an existing change                   |
+ | `/opsx:ff`       | Fast-forward: create all artifacts at once               |
+ | `/opsx:verify`   | Verify implementation matches artifacts                  |
 
 ---
 
 ## What's Next?
 
-Try `/opsx:new` or `/opsx:ff` on something you actually want to build. You've got the rhythm now!
+Try `/opsx:propose` on something you actually want to build. You've got the rhythm now!
 ```
 
 ---
@@ -501,17 +518,25 @@ If the user says they just want to see the commands or skip the tutorial:
 ```
 ## OpenSpec Quick Reference
 
-| Command | What it does |
-|---------|--------------|
-| `/opsx:explore` | Think through problems (no code changes) |
-| `/opsx:new <name>` | Start a new change, step by step |
-| `/opsx:ff <name>` | Fast-forward: all artifacts at once |
-| `/opsx:continue <name>` | Continue an existing change |
-| `/opsx:apply <name>` | Implement tasks |
-| `/opsx:verify <name>` | Verify implementation |
-| `/opsx:archive <name>` | Archive when done |
+**Core workflow:**
 
-Try `/opsx:new` to start your first change, or `/opsx:ff` if you want to move fast.
+ | Command                  | What it does                               |
+ |--------------------------|--------------------------------------------|
+ | `/opsx:propose <name>` | Create a change and generate all artifacts |
+ | `/opsx:explore`        | Think through problems (no code changes)   |
+ | `/opsx:apply <name>`   | Implement tasks                            |
+ | `/opsx:archive <name>` | Archive when done                          |
+
+**Additional commands:**
+
+ | Command                   | What it does                        |
+ |---------------------------|-------------------------------------|
+ | `/opsx:new <name>`      | Start a new change, step by step    |
+ | `/opsx:continue <name>` | Continue an existing change         |
+ | `/opsx:ff <name>`       | Fast-forward: all artifacts at once |
+ | `/opsx:verify <name>`   | Verify implementation               |
+
+Try `/opsx:propose` to start your first change.
 ```
 
 Exit gracefully.

--- a/.github/skills/openspec-sync-specs/SKILL.md
+++ b/.github/skills/openspec-sync-specs/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Sync delta specs from a change to main specs.

--- a/.github/skills/openspec-verify-change/SKILL.md
+++ b/.github/skills/openspec-verify-change/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires openspec CLI.
 metadata:
   author: openspec
   version: "1.0"
-  generatedBy: "1.1.1"
+  generatedBy: "1.3.1"
 ---
 
 Verify that an implementation matches the change artifacts (specs, tasks, design).
@@ -39,7 +39,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
    openspec instructions apply --change "<name>" --json
    ```
 
-   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+   This returns the change directory and `contextFiles` (artifact ID -> array of concrete file paths). Read all available artifacts from `contextFiles`.
 
 4. **Initialize verification report structure**
 
@@ -53,7 +53,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 5. **Verify Completeness**
 
    **Task Completion**:
-   - If tasks.md exists in contextFiles, read it
+   - If `contextFiles.tasks` exists, read every file path in it
    - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
    - Count complete vs total tasks
    - If incomplete tasks exist:
@@ -92,7 +92,7 @@ Verify that an implementation matches the change artifacts (specs, tasks, design
 7. **Verify Coherence**
 
    **Design Adherence**:
-   - If design.md exists in contextFiles:
+   - If `contextFiles.design` exists:
      - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
      - Verify implementation follows those decisions
      - If contradiction detected:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Loop(body, until, maxAttempts, exhausted, mutate?)` operator** — first-class bounded iteration on the right rail. Runs a nested sub-pipeline body repeatedly until a break condition (`until`) is satisfied or a hard attempt cap (`maxAttempts`) is reached. On exhaustion, exits with a caller-defined `Left` via the `exhausted` delegate. An optional `mutate` hook transforms the payload between iterations. Sync and async overloads provided. `Loop` is not nested (unavailable inside `BranchBuilder` or `LoopBuilder`) for v1.
+
 ## [4.0.0] - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ All step operators are registered on `RailwayStepsBuilder` inside the `steps` la
 
 The most important distinction between operators is **whether their result is fed back into the pipeline**:
 
-- **Payload-replacing** (`Do`, `Branch`, `Recover`) — the operator's return value becomes the new pipeline state. Downstream operators see the updated payload.
+- **Payload-replacing** (`Do`, `Branch`, `Loop`, `Recover`) — the operator's return value becomes the new pipeline state. Downstream operators see the updated payload.
 - **Pass-through** (`Tap`, `TryTap`, `Effects`, `TryEffects`, `Ensure`) — the operator reads the payload but its return value is **not** fed back. The payload flowing to the next operator is identical to what came in.
 - **Fire-and-forget** (`Detach`) — result is discarded and nothing is awaited.
 - **Out-of-band** (`Finally`) — runs outside the pipeline; its return value is discarded and does not affect the pipeline result.
@@ -342,6 +342,60 @@ The inner builder (`BranchBuilder`) exposes `Do`, `Tap`, `TryTap`, `Effects`, `T
 
 ---
 
+### Loop
+
+Executes a bounded iteration on the right rail. The body sub-pipeline (`LoopBuilder`) runs repeatedly until `until` returns `true` or `maxAttempts` is exhausted.
+
+**Iteration order** (1-indexed attempt `N`):
+1. Run the body. If it returns `Left`, exit the loop immediately with that `Left`.
+2. Evaluate `until(payload, N)`. If `true`, exit with `Right(payload)`.
+3. If `N == maxAttempts`, exit with `Left(exhausted(payload, N))`.
+4. Apply `mutate(payload, N)` (if provided) to produce the starting payload for iteration `N+1`.
+5. Repeat.
+
+`mutate` never runs before the first iteration or after the loop exits. `exhausted` is the caller's delegate — the library has no default because `TError` is open. `maxAttempts` must be `>= 1`; the builder throws `ArgumentOutOfRangeException` at registration time if not.
+
+`Recover<TErr>` inside the body catches errors scoped to that iteration only — it does not carry over to subsequent iterations.
+
+The inner builder (`LoopBuilder`) exposes `Do`, `Tap`, `TryTap`, `Effects`, `TryEffects`, `Branch`, `Ensure`, and `Recover`. `Loop`, `Detach`, and `Finally` are intentionally excluded.
+
+```csharp
+// Poll-for-ready: no mutate needed
+.Loop(
+    body: lb => lb
+        .Do(async (payload, ct) =>
+        {
+            var ready = await jobService.IsReadyAsync(payload.JobId, ct);
+            return Either<Error, Payload>.FromRight(payload with { Ready = ready });
+        }),
+    until: (payload, _) => payload.Ready,
+    maxAttempts: 10,
+    exhausted: (payload, attempts) => new Error($"Job {payload.JobId} not ready after {attempts} polls"))
+
+// Retry-with-mutation: Recover keeps iterating on transient failures; mutate adjusts for each attempt
+.Loop(
+    body: lb => lb
+        .Do(async (payload, ct) =>
+        {
+            var result = await externalService.CallAsync(payload.Endpoint, ct);
+            if (!result.Success)
+                return Either<Error, Payload>.FromLeft(new TransientError(result.StatusCode));
+            return Either<Error, Payload>.FromRight(payload with { Response = result.Body });
+        })
+        .Recover<TransientError>((err, last) => last with { LastError = err }),
+    until: (payload, _) => payload.Response != null,
+    maxAttempts: 5,
+    exhausted: (payload, attempts) => new Error($"Max retries ({attempts}) exceeded"),
+    mutate: (payload, attempt) => payload with { DelayMs = attempt * 100 })
+```
+
+**Behavior:**
+- **Result IS fed back into the pipeline.** The loop's final `Either` state (from `until`, body `Left`, or exhaustion) replaces the main pipeline state.
+- **On Right:** runs the body iteratively according to the iteration order above
+- **On Left (incoming):** passes through unchanged — `body`, `until`, `mutate`, and `exhausted` are not invoked
+
+---
+
 ### Recover
 
 Recovers from a typed error. When the pipeline is on `Left` and the error value is assignable to `TErr`, the handler runs and its returned payload transitions the pipeline back to `Right`. Non-matching errors and `Right` values pass through unchanged.
@@ -411,6 +465,7 @@ The activity receives the **last known `Right` payload** — if the pipeline nev
 | `TryEffects` | No — payload unchanged | Runs all; state passes through | Skips | Swallowed |
 | `Detach` | No — discarded entirely | Schedules background tasks; returns immediately | Skips | Swallowed |
 | `Branch` | **Yes** — sub-pipeline result | Runs sub-pipeline if predicate true; result is the new state | Skips | Propagate |
+| `Loop` | **Yes** — loop's final Either | Runs body iteratively; exits on `until`, body `Left`, or exhaustion | Passes through unchanged | Propagate |
 | `Recover<TErr>` | **Yes** — recovered payload | Skips | Matching error: handler result becomes new Right | Propagate |
 | `Finally` | No — discarded entirely | Always runs; result ignored | Always runs; result ignored | Swallowed |
 

--- a/Zooper.Bee.Example/Program.cs
+++ b/Zooper.Bee.Example/Program.cs
@@ -9,6 +9,8 @@ await RunOrderProcessingExample();
 await RunBranchingExample();
 await RunRecoveryExample();
 await RunParameterlessExample();
+await RunPollForReadyExample();
+await RunRetryWithMutationExample();
 Console.WriteLine("\nAll examples complete.");
 return;
 
@@ -105,6 +107,81 @@ static async Task RunParameterlessExample()
     Console.WriteLine($"  Counter after 3 steps: {result.Right.FinalCount}");
 }
 
+// ── Loop: poll-for-ready ─────────────────────────────────────────────────────
+
+static async Task RunPollForReadyExample()
+{
+    Console.WriteLine("\n=== Loop: Poll-for-Ready ===");
+
+    // Simulate a job that becomes ready on the 3rd poll.
+    var railway = Railway.Create<PollRequest, PollPayload, PollSuccess, PollError>(
+        r => new PollPayload(r.JobId),
+        p => new PollSuccess(p.JobId, p.PollCount),
+        steps => steps
+            .Loop(
+                body: lb => lb
+                    .Do(async (p, ct) =>
+                    {
+                        // Simulate checking job readiness.
+                        await Task.Delay(5, ct);
+                        var ready = p.PollCount + 1 >= 3;
+                        Console.WriteLine($"  Poll {p.PollCount + 1}: ready={ready}");
+                        return Either<PollError, PollPayload>.FromRight(
+                            p with { PollCount = p.PollCount + 1, Ready = ready });
+                    }),
+                until: (p, _) => p.Ready,
+                maxAttempts: 10,
+                exhausted: (p, a) => new PollError("TIMEOUT", a)));
+
+    var result = await railway.Execute(new PollRequest("job-abc"));
+    Console.WriteLine(result.IsRight
+        ? $"  Job ready after {result.Right.PollCount} poll(s)"
+        : $"  Timed out after {result.Left!.Attempts} attempt(s)");
+}
+
+// ── Loop: retry-with-mutation ────────────────────────────────────────────────
+
+static async Task RunRetryWithMutationExample()
+{
+    Console.WriteLine("\n=== Loop: Retry-with-Mutation ===");
+
+    // Simulate a flaky service: fails (503) on attempts 1 and 2, succeeds on 3.
+    var railway = Railway.Create<RetryRequest, RetryPayload, RetrySuccess, RetryError>(
+        r => new RetryPayload(r.Endpoint),
+        p => new RetrySuccess(p.Response!, p.Attempt),
+        steps => steps
+            .Loop(
+                body: lb => lb
+                    .Do(async (p, ct) =>
+                    {
+                        // Simulate network call with optional back-off delay.
+                        if (p.DelayMs > 0) await Task.Delay(p.DelayMs, ct);
+                        Console.WriteLine($"  Attempt {p.Attempt + 1} → calling {p.Endpoint}");
+                        // Fail on attempts 1 and 2.
+                        if (p.Attempt < 2)
+                            return Either<RetryError, RetryPayload>.FromLeft(
+                                new ServiceUnavailableError("SERVICE_UNAVAILABLE", 503));
+                        return Either<RetryError, RetryPayload>.FromRight(
+                            p with { Attempt = p.Attempt + 1, Response = "OK" });
+                    })
+                    // Recover per-iteration: a 503 is transient — keep iterating.
+                    .Recover<ServiceUnavailableError>((err, last) =>
+                    {
+                        Console.WriteLine($"  Transient {err.StatusCode} on attempt {last.Attempt + 1} — will retry");
+                        return last with { Attempt = last.Attempt + 1 };
+                    }),
+                until: (p, _) => p.Response != null,
+                maxAttempts: 5,
+                exhausted: (p, a) => new RetryError("MAX_RETRIES", a),
+                // Mutate: increase delay between iterations (simple linear back-off).
+                mutate: (p, a) => p with { DelayMs = a * 10 }));
+
+    var result = await railway.Execute(new RetryRequest("https://api.example.com/data"));
+    Console.WriteLine(result.IsRight
+        ? $"  Succeeded: '{result.Right.Response}' after {result.Right.Attempts} attempt(s)"
+        : $"  Failed: {result.Left!.Code} after {result.Left.Attempts} attempt(s)");
+}
+
 // ===== Records =====
 record OrderRequest(string CustomerId, decimal Amount);
 record OrderPayload(string CustomerId, decimal Amount, string? OrderId = null, string? Status = null);
@@ -125,3 +202,14 @@ record InsufficientFundsError(string Code, decimal Shortfall) : PayError(Code);
 record SyncPayload(int Counter = 0);
 record SyncSuccess(int FinalCount);
 record SyncError(string Code);
+
+record PollRequest(string JobId);
+record PollPayload(string JobId, int PollCount = 0, bool Ready = false);
+record PollSuccess(string JobId, int PollCount);
+record PollError(string Code, int Attempts);
+
+record RetryRequest(string Endpoint);
+record RetryPayload(string Endpoint, int Attempt = 0, string? Response = null, int DelayMs = 0);
+record RetrySuccess(string Response, int Attempts);
+record RetryError(string Code, int Attempts);
+record ServiceUnavailableError(string Code, int StatusCode) : RetryError(Code, 0);

--- a/Zooper.Bee.Example/Zooper.Bee.Example.csproj
+++ b/Zooper.Bee.Example/Zooper.Bee.Example.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Zooper.Bee.Tests/LoopTests.cs
+++ b/Zooper.Bee.Tests/LoopTests.cs
@@ -1,0 +1,518 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using Zooper.Fox;
+
+namespace Zooper.Bee.Tests;
+
+/// <summary>
+/// Tests for the Loop operator on RailwayStepsBuilder.
+///
+/// NOTE — negative compile assertions (task 4.17: LoopBuilder must not expose Loop, Detach, Finally):
+/// These cannot be expressed as xUnit tests. The absence of these methods is enforced at compile time
+/// by simply not defining them on LoopBuilder. Any attempt to call .Loop(), .Detach(), or .Finally()
+/// inside a loop body will produce a CS1061 compile error.
+/// </summary>
+public class LoopTests
+{
+    // ───── shared types ─────────────────────────────────────────────────────
+
+    private record Req(int Value);
+    private record Pay(int Value, int Attempts = 0, string? Note = null);
+    private record Succ(int Value, int Attempts);
+    private record Err(string Code);
+    private record TransientError(string Code) : Err(Code);
+
+    private static Railway<Req, Succ, Err> Build(
+        Action<RailwayStepsBuilder<Req, Pay, Succ, Err>> configure)
+        => Railway.Create<Req, Pay, Succ, Err>(
+            r => new Pay(r.Value),
+            p => new Succ(p.Value, p.Attempts),
+            configure);
+
+    // ───── 4.1  Body short-circuit ───────────────────────────────────────────
+
+    [Fact]
+    public async Task Loop_BodyLeft_ExitsImmediately_SkipsUntilMutateExhausted()
+    {
+        var untilCalled = new List<int>();
+        var mutateCalled = new List<int>();
+        var exhaustedCalled = false;
+
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb
+                    .Do(p => p.Attempts == 1   // fail on 2nd iteration (index 1)
+                        ? Either<Err, Pay>.FromLeft(new Err("BODY_ERR"))
+                        : Either<Err, Pay>.FromRight(p with { Attempts = p.Attempts + 1 })),
+                until: (p, a) => { untilCalled.Add(a); return false; },
+                maxAttempts: 5,
+                exhausted: (p, a) => { exhaustedCalled = true; return new Err("EXHAUSTED"); },
+                mutate: (p, a) => { mutateCalled.Add(a); return p; }));
+
+        var result = await railway.Execute(new Req(0));
+
+        result.IsLeft.Should().BeTrue();
+        result.Left!.Code.Should().Be("BODY_ERR");
+        untilCalled.Should().HaveCount(1);   // ran for iteration 1 only
+        mutateCalled.Should().HaveCount(1);  // ran once (between iter 1→2)
+        exhaustedCalled.Should().BeFalse();
+    }
+
+    // ───── 4.2  Break on until ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Loop_UntilTrue_ExitsRight_SkipsMutateExhausted()
+    {
+        var mutateCalled = false;
+        var exhaustedCalled = false;
+
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb.Do(p => Either<Err, Pay>.FromRight(p with { Attempts = p.Attempts + 1 })),
+                until: (_, a) => a == 1,  // break immediately on first iteration
+                maxAttempts: 5,
+                exhausted: (p, a) => { exhaustedCalled = true; return new Err("EXHAUSTED"); },
+                mutate: (p, a) => { mutateCalled = true; return p; }));
+
+        var result = await railway.Execute(new Req(42));
+
+        result.IsRight.Should().BeTrue();
+        result.Right!.Value.Should().Be(42);
+        result.Right.Attempts.Should().Be(1);
+        mutateCalled.Should().BeFalse();
+        exhaustedCalled.Should().BeFalse();
+    }
+
+    // ───── 4.3  Exhaustion ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Loop_Exhaustion_ExitsLeft_MutateNotCalledAfterFinalIteration()
+    {
+        var mutateCalls = new List<int>();
+
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb.Do(p => Either<Err, Pay>.FromRight(p with { Attempts = p.Attempts + 1 })),
+                until: (_, _) => false,
+                maxAttempts: 3,
+                exhausted: (p, a) => new Err($"EXHAUSTED:{a}"),
+                mutate: (p, a) => { mutateCalls.Add(a); return p; }));
+
+        var result = await railway.Execute(new Req(0));
+
+        result.IsLeft.Should().BeTrue();
+        result.Left!.Code.Should().Be("EXHAUSTED:3");
+        mutateCalls.Should().BeEquivalentTo([1, 2], options => options.WithStrictOrdering());
+    }
+
+    // ───── 4.4  Mutate between iterations ───────────────────────────────────
+
+    [Fact]
+    public async Task Loop_Mutate_TransformsPayloadForNextIteration()
+    {
+        var startValues = new List<int>();
+
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb.Do(p =>
+                {
+                    startValues.Add(p.Value);
+                    return Either<Err, Pay>.FromRight(p with { Attempts = p.Attempts + 1 });
+                }),
+                until: (_, a) => a == 2,  // break after 2nd iteration
+                maxAttempts: 5,
+                exhausted: (p, a) => new Err("EXHAUSTED"),
+                mutate: (p, a) => p with { Value = p.Value + 10 }));
+
+        var result = await railway.Execute(new Req(1));
+
+        result.IsRight.Should().BeTrue();
+        startValues.Should().BeEquivalentTo([1, 11], options => options.WithStrictOrdering());
+    }
+
+    // ───── 4.5  No-mutate path ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Loop_NoMutate_NextIterationStartsWithSamePayload()
+    {
+        var startValues = new List<int>();
+
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb.Do(p =>
+                {
+                    startValues.Add(p.Value);
+                    return Either<Err, Pay>.FromRight(p with { Attempts = p.Attempts + 1 });
+                }),
+                until: (_, a) => a == 2,
+                maxAttempts: 5,
+                exhausted: (p, a) => new Err("EXHAUSTED")));
+        // no mutate
+
+        var result = await railway.Execute(new Req(7));
+
+        result.IsRight.Should().BeTrue();
+        startValues.Should().BeEquivalentTo([7, 7], options => options.WithStrictOrdering());
+    }
+
+    // ───── 4.6  Incoming Left passthrough ────────────────────────────────────
+
+    [Fact]
+    public async Task Loop_IncomingLeft_PassesThroughUnchanged()
+    {
+        var bodyCalled = false;
+        var untilCalled = false;
+
+        var railway = Build(b => b
+            .Do(_ => Either<Err, Pay>.FromLeft(new Err("UPSTREAM")))
+            .Loop(
+                body: lb => lb.Do(p => { bodyCalled = true; return Either<Err, Pay>.FromRight(p); }),
+                until: (_, _) => { untilCalled = true; return true; },
+                maxAttempts: 3,
+                exhausted: (p, a) => new Err("EXHAUSTED")));
+
+        var result = await railway.Execute(new Req(0));
+
+        result.IsLeft.Should().BeTrue();
+        result.Left!.Code.Should().Be("UPSTREAM");
+        bodyCalled.Should().BeFalse();
+        untilCalled.Should().BeFalse();
+    }
+
+    // ───── 4.7  maxAttempts = 1 ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Loop_MaxAttemptsOne_UntilFalse_ExitsExhausted()
+    {
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb.Do(p => Either<Err, Pay>.FromRight(p with { Attempts = 1 })),
+                until: (_, _) => false,
+                maxAttempts: 1,
+                exhausted: (p, a) => new Err($"EXHAUSTED:{a}")));
+
+        var result = await railway.Execute(new Req(0));
+
+        result.IsLeft.Should().BeTrue();
+        result.Left!.Code.Should().Be("EXHAUSTED:1");
+    }
+
+    [Fact]
+    public async Task Loop_MaxAttemptsOne_UntilTrue_ExitsRight()
+    {
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb.Do(p => Either<Err, Pay>.FromRight(p with { Attempts = 1 })),
+                until: (_, _) => true,
+                maxAttempts: 1,
+                exhausted: (p, a) => new Err("EXHAUSTED")));
+
+        var result = await railway.Execute(new Req(5));
+
+        result.IsRight.Should().BeTrue();
+        result.Right!.Value.Should().Be(5);
+    }
+
+    // ───── 4.8  maxAttempts validation ───────────────────────────────────────
+
+    [Fact]
+    public void Loop_MaxAttemptsZero_ThrowsAtRegistration()
+    {
+        Action act = () => Build(b => b
+            .Loop(
+                body: _ => { },
+                until: (_, _) => true,
+                maxAttempts: 0,
+                exhausted: (p, a) => new Err("E")));
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("maxAttempts");
+    }
+
+    [Fact]
+    public void Loop_NegativeMaxAttempts_ThrowsAtRegistration()
+    {
+        Action act = () => Build(b => b
+            .Loop(
+                body: _ => { },
+                until: (_, _) => true,
+                maxAttempts: -5,
+                exhausted: (p, a) => new Err("E")));
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("maxAttempts");
+    }
+
+    // ───── 4.9  Empty body ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Loop_EmptyBody_BehavesAsPurePoll()
+    {
+        // An empty body leaves the payload unchanged; until still receives it each iteration.
+        var untilAttempts = new List<int>();
+
+        var railway = Build(b => b
+            .Loop(
+                body: _ => { },  // empty
+                until: (_, a) => { untilAttempts.Add(a); return a == 3; },
+                maxAttempts: 10,
+                exhausted: (p, a) => new Err("EXHAUSTED")));
+
+        var result = await railway.Execute(new Req(99));
+
+        result.IsRight.Should().BeTrue();
+        result.Right!.Value.Should().Be(99);
+        untilAttempts.Should().BeEquivalentTo([1, 2, 3], options => options.WithStrictOrdering());
+    }
+
+    // ───── 4.10  Recover inside body — keeps loop iterating ──────────────────
+
+    [Fact]
+    public async Task Loop_RecoverInsideBody_ConvertsLeftToRight_LoopContinues()
+    {
+        // Body always fails on iteration 1, Recover catches it → loop continues to iteration 2.
+        var iterationCount = 0;
+
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb
+                    .Do(p =>
+                    {
+                        iterationCount++;
+                        return iterationCount == 1
+                            ? Either<Err, Pay>.FromLeft(new TransientError("TRANSIENT"))
+                            : Either<Err, Pay>.FromRight(p with { Attempts = p.Attempts + 1 });
+                    })
+                    .Recover<TransientError>((err, last) => last with { Note = "recovered" }),
+                until: (_, a) => a == 2,
+                maxAttempts: 5,
+                exhausted: (p, a) => new Err("EXHAUSTED")));
+
+        var result = await railway.Execute(new Req(0));
+
+        result.IsRight.Should().BeTrue();
+        iterationCount.Should().Be(2);
+    }
+
+    // ───── 4.11  Recover scoping — per-iteration ─────────────────────────────
+
+    [Fact]
+    public async Task Loop_RecoverScopedToIteration_DoesNotCrossIterationBoundary()
+    {
+        // Recover catches the error in iteration 1, converting it to Right.
+        // In iteration 2, a different Left is raised that no Recover matches — loop exits Left.
+        var iterationCount = 0;
+
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb
+                    .Do(p =>
+                    {
+                        iterationCount++;
+                        return iterationCount == 1
+                            ? Either<Err, Pay>.FromLeft(new TransientError("TRANSIENT"))
+                            : Either<Err, Pay>.FromLeft(new Err("FATAL"));
+                    })
+                    .Recover<TransientError>((err, last) => last),
+                until: (_, _) => false,
+                maxAttempts: 5,
+                exhausted: (p, a) => new Err("EXHAUSTED")));
+
+        var result = await railway.Execute(new Req(0));
+
+        result.IsLeft.Should().BeTrue();
+        result.Left!.Code.Should().Be("FATAL");
+        iterationCount.Should().Be(2);
+    }
+
+    // ───── 4.12  Attempt index consistency ───────────────────────────────────
+
+    [Fact]
+    public async Task Loop_AttemptIndex_ConsistentAcrossUntilMutateExhausted()
+    {
+        var untilAttempts = new List<int>();
+        var mutateAttempts = new List<int>();
+        int exhaustedAttempt = 0;
+
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb.Do(p => Either<Err, Pay>.FromRight(p)),
+                until: (_, a) => { untilAttempts.Add(a); return false; },
+                maxAttempts: 3,
+                exhausted: (p, a) => { exhaustedAttempt = a; return new Err("EXHAUSTED"); },
+                mutate: (p, a) => { mutateAttempts.Add(a); return p; }));
+
+        await railway.Execute(new Req(0));
+
+        // until called for iterations 1, 2, 3
+        untilAttempts.Should().BeEquivalentTo([1, 2, 3], options => options.WithStrictOrdering());
+        // mutate called between 1→2 and 2→3 (not after final)
+        mutateAttempts.Should().BeEquivalentTo([1, 2], options => options.WithStrictOrdering());
+        // exhausted called with attempt = 3
+        exhaustedAttempt.Should().Be(3);
+    }
+
+    // ───── 4.13  Async hooks ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Loop_AsyncHooks_AreAwaited_CancellationTokenPropagated()
+    {
+        var cts = new CancellationTokenSource();
+        var untilToken = CancellationToken.None;
+        var mutateToken = CancellationToken.None;
+
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb.Do(async (p, ct) =>
+                {
+                    await Task.Yield();
+                    return Either<Err, Pay>.FromRight(p with { Attempts = p.Attempts + 1 });
+                }),
+                until: async (p, a, ct) =>
+                {
+                    untilToken = ct;
+                    await Task.Yield();
+                    return a == 2;
+                },
+                maxAttempts: 5,
+                exhausted: async (p, a, ct) =>
+                {
+                    await Task.Yield();
+                    return new Err("EXHAUSTED");
+                },
+                mutate: async (p, a, ct) =>
+                {
+                    mutateToken = ct;
+                    await Task.Yield();
+                    return p;
+                }));
+
+        var result = await railway.Execute(new Req(0), cts.Token);
+
+        result.IsRight.Should().BeTrue();
+        untilToken.Should().Be(cts.Token);
+        mutateToken.Should().Be(cts.Token);
+    }
+
+    // ───── 4.14  Mixed sync/async hooks ──────────────────────────────────────
+
+    [Fact]
+    public async Task Loop_MixedSyncAsync_CompilesAndExecutes()
+    {
+        // Sync until + async mutate via the async overload
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb.Do(p => Either<Err, Pay>.FromRight(p with { Attempts = p.Attempts + 1 })),
+                until: (p, a, _) => Task.FromResult(a == 2),   // sync until lifted
+                maxAttempts: 5,
+                exhausted: (p, a, _) => Task.FromResult(new Err("EXHAUSTED") as Err),
+                mutate: async (p, a, ct) =>                     // async mutate
+                {
+                    await Task.Yield();
+                    return p with { Value = p.Value + 1 };
+                }));
+
+        var result = await railway.Execute(new Req(0));
+
+        result.IsRight.Should().BeTrue();
+        result.Right!.Value.Should().Be(1);   // one mutate ran (between iter 1 and 2)
+    }
+
+    // ───── 4.15  Registration order ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Loop_RegistrationOrder_PreservedAroundLoop()
+    {
+        var order = new List<string>();
+
+        var railway = Build(b => b
+            .Do(p => { order.Add("before"); return Either<Err, Pay>.FromRight(p); })
+            .Loop(
+                body: lb => lb.Do(p => { order.Add("body"); return Either<Err, Pay>.FromRight(p); }),
+                until: (_, a) => { order.Add("until"); return a == 1; },
+                maxAttempts: 3,
+                exhausted: (p, a) => new Err("EXHAUSTED"))
+            .Do(p => { order.Add("after"); return Either<Err, Pay>.FromRight(p); }));
+
+        await railway.Execute(new Req(0));
+
+        order.Should().BeEquivalentTo(["before", "body", "until", "after"],
+            options => options.WithStrictOrdering());
+    }
+
+    // ───── 4.16  LoopBuilder operator surface (compile test) ─────────────────
+
+    [Fact]
+    public async Task LoopBuilder_ExposesAllDocumentedOperators()
+    {
+        // This test compiles and runs all allowed operators on LoopBuilder.
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb
+                    .Do(p => Either<Err, Pay>.FromRight(p))                                        // Do (sync)
+                    .Do(async (p, ct) => { await Task.Yield(); return Either<Err, Pay>.FromRight(p); })  // Do (async)
+                    .Tap(p => { _ = p.Value; })                                                    // Tap (sync)
+                    .Tap(async (p, ct) => { await Task.Yield(); })                                 // Tap (async)
+                    .TryTap(p => { _ = p.Value; })                                                 // TryTap (sync)
+                    .TryTap(async (p, ct) => { await Task.Yield(); })                              // TryTap (async)
+                    .Effects(fx => fx.Do(p => { _ = p.Value; }))                                   // Effects
+                    .TryEffects(fx => fx.Do(p => { _ = p.Value; }))                                // TryEffects
+                    .Branch(p => false, br => br.Do(p => Either<Err, Pay>.FromRight(p)))           // Branch
+                    .Ensure(p => true, p => new Err("E"))                                          // Ensure
+                    .Recover<Err>((err, last) => last),                                            // Recover
+                until: (_, a) => a == 1,
+                maxAttempts: 1,
+                exhausted: (p, a) => new Err("EXHAUSTED")));
+
+        var result = await railway.Execute(new Req(0));
+        result.IsRight.Should().BeTrue();
+    }
+
+    // ───── 4.17  LoopBuilder must not expose Loop, Detach, Finally ───────────
+    //
+    // Negative compile assertions cannot be expressed as xUnit tests.
+    // The absence of Loop, Detach, and Finally on LoopBuilder is enforced at compile
+    // time — any attempt to call those methods inside a loop body produces CS1061.
+    //
+    // Uncomment the lines below (in a scratch file) to verify:
+    //   lb.Loop(...);    // CS1061 — 'LoopBuilder<Pay, Err>' does not contain a definition for 'Loop'
+    //   lb.Detach(...);  // CS1061 — 'LoopBuilder<Pay, Err>' does not contain a definition for 'Detach'
+    //   lb.Finally(...); // CS1061 — 'LoopBuilder<Pay, Err>' does not contain a definition for 'Finally'
+
+    // ───── 4.18  Inner Branch inside Loop body ───────────────────────────────
+
+    [Fact]
+    public async Task Loop_InnerBranch_RunsConditionallyPerIteration()
+    {
+        var branchExecutedAttempts = new List<int>();
+        var attemptTracker = 0;
+
+        var railway = Build(b => b
+            .Loop(
+                body: lb => lb
+                    .Do(p =>
+                    {
+                        attemptTracker++;
+                        return Either<Err, Pay>.FromRight(p with { Attempts = attemptTracker });
+                    })
+                    .Branch(
+                        when: p => p.Attempts % 2 == 0,   // branch runs on even attempts
+                        branch: br => br.Do(p =>
+                        {
+                            branchExecutedAttempts.Add(p.Attempts);
+                            return Either<Err, Pay>.FromRight(p with { Note = "branched" });
+                        })),
+                until: (_, a) => a == 4,
+                maxAttempts: 10,
+                exhausted: (p, a) => new Err("EXHAUSTED")));
+
+        var result = await railway.Execute(new Req(0));
+
+        result.IsRight.Should().BeTrue();
+        branchExecutedAttempts.Should().BeEquivalentTo([2, 4], options => options.WithStrictOrdering());
+    }
+}

--- a/Zooper.Bee/LoopBuilder.cs
+++ b/Zooper.Bee/LoopBuilder.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Zooper.Fox;
+
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace Zooper.Bee;
+
+/// <summary>
+/// Builder for the body sub-pipeline used by the <c>Loop</c> operator on
+/// <see cref="RailwayStepsBuilder{TRequest,TPayload,TSuccess,TError}"/>.
+/// Exposes <c>Do</c>, <c>Tap</c>, <c>Effects</c>, <c>TryTap</c>, <c>TryEffects</c>,
+/// <c>Branch</c>, <c>Ensure</c>, and <c>Recover</c>.
+/// <c>Loop</c>, <c>Detach</c>, and <c>Finally</c> are intentionally omitted to
+/// prevent nested loops and keep lifecycle concerns at the top level.
+/// </summary>
+/// <typeparam name="TPayload">The type of the payload.</typeparam>
+/// <typeparam name="TError">The type of the error.</typeparam>
+public sealed class LoopBuilder<TPayload, TError>
+{
+	// Internal operator list: (currentEither, lastRightSnapshot, ct) -> newEither
+	internal List<Func<Either<TError, TPayload>, TPayload, CancellationToken, Task<Either<TError, TPayload>>>> Operators { get; } = [];
+
+	/// <summary>
+	/// Adds an asynchronous payload-progression step.
+	/// <para>On <c>Right</c>: executes and replaces the rail state with the returned <see cref="Either{TError,TPayload}"/>.</para>
+	/// <para>On <c>Left</c>: passes through unchanged without invoking the delegate.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> Do(Func<TPayload, CancellationToken, Task<Either<TError, TPayload>>> activity)
+	{
+		Operators.Add((current, _, ct) =>
+			current.IsRight
+				? activity(current.Right!, ct)
+				: Task.FromResult(current));
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a synchronous payload-progression step.
+	/// <para>On <c>Right</c>: executes and replaces the rail state with the returned <see cref="Either{TError,TPayload}"/>.</para>
+	/// <para>On <c>Left</c>: passes through unchanged without invoking the delegate.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> Do(Func<TPayload, Either<TError, TPayload>> activity)
+	{
+		Operators.Add((current, _, _ct) =>
+			Task.FromResult(current.IsRight ? activity(current.Right!) : current));
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a strict pass-through side effect that does not change the payload.
+	/// <para>On <c>Right</c>: executes; a thrown exception propagates to the caller.</para>
+	/// <para>On <c>Left</c>: passes through without invoking the delegate.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> Tap(Action<TPayload> effect)
+	{
+		Operators.Add((current, _, _ct) =>
+		{
+			if (!current.IsRight) return Task.FromResult(current);
+			effect(current.Right!);
+			return Task.FromResult(current);
+		});
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a strict asynchronous pass-through side effect that does not change the payload.
+	/// <para>On <c>Right</c>: executes; exceptions propagate to the caller.</para>
+	/// <para>On <c>Left</c>: passes through without invoking the delegate.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> Tap(Func<TPayload, CancellationToken, Task> effect)
+	{
+		Operators.Add(async (current, _, ct) =>
+		{
+			if (!current.IsRight) return current;
+			await effect(current.Right!, ct);
+			return current;
+		});
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a strict asynchronous pass-through side effect with an explicit error channel.
+	/// <para>On <c>Right</c>: executes; returning <c>Left(err)</c> transitions the rail to <c>Left</c>; payload is unchanged on success.</para>
+	/// <para>On <c>Left</c>: passes through without invoking the delegate.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> Tap(Func<TPayload, CancellationToken, Task<Either<TError, Unit>>> effect)
+	{
+		Operators.Add(async (current, _, ct) =>
+		{
+			if (!current.IsRight) return current;
+			var result = await effect(current.Right!, ct);
+			return result.IsLeft
+				? Either<TError, TPayload>.FromLeft(result.Left!)
+				: current;
+		});
+		return this;
+	}
+
+	/// <summary>
+	/// Adds grouped strict pass-through side effects. The first inner failure transitions the rail to <c>Left</c>;
+	/// remaining inner effects do not run. The payload is unchanged on success.
+	/// <para>On <c>Left</c>: passes through without invoking any inner effect.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> Effects(Action<EffectsBuilder<TPayload, TError>> configure)
+	{
+		var builder = new EffectsBuilder<TPayload, TError>();
+		configure(builder);
+		var effects = builder.Effects;
+
+		Operators.Add(async (current, _, ct) =>
+		{
+			if (!current.IsRight) return current;
+			var payload = current.Right!;
+			foreach (var effect in effects)
+			{
+				var result = await effect(payload, ct);
+				if (result.IsLeft)
+					return Either<TError, TPayload>.FromLeft(result.Left!);
+			}
+			return current;
+		});
+		return this;
+	}
+
+	/// <summary>
+	/// Adds best-effort grouped side effects. Failures in inner effects are swallowed; every inner effect is
+	/// attempted in registration order. The rail remains on <c>Right</c> regardless of inner failures.
+	/// <para>On <c>Left</c>: passes through without invoking any inner effect.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> TryEffects(Action<EffectsBuilder<TPayload, TError>> configure)
+	{
+		var builder = new EffectsBuilder<TPayload, TError>();
+		configure(builder);
+		var effects = builder.Effects;
+
+		Operators.Add(async (current, _, ct) =>
+		{
+			if (!current.IsRight) return current;
+			var payload = current.Right!;
+			foreach (var effect in effects)
+			{
+				try { await effect(payload, ct); }
+				catch { /* swallow */ }
+			}
+			return current;
+		});
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a best-effort single side effect whose failure does not affect the rail.
+	/// Thrown exceptions are swallowed. The payload is unchanged.
+	/// <para>On <c>Left</c>: passes through without invoking the delegate.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> TryTap(Action<TPayload> effect)
+	{
+		Operators.Add((current, _, _ct) =>
+		{
+			if (!current.IsRight) return Task.FromResult(current);
+			try { effect(current.Right!); } catch { /* swallow */ }
+			return Task.FromResult(current);
+		});
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a best-effort asynchronous single side effect whose failure does not affect the rail.
+	/// Exceptions and <c>Left</c> returns are swallowed. The payload is unchanged.
+	/// <para>On <c>Left</c>: passes through without invoking the delegate.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> TryTap(Func<TPayload, CancellationToken, Task> effect)
+	{
+		Operators.Add(async (current, _, ct) =>
+		{
+			if (!current.IsRight) return current;
+			try { await effect(current.Right!, ct); } catch { /* swallow */ }
+			return current;
+		});
+		return this;
+	}
+
+	/// <summary>
+	/// Conditionally enters a sub-pipeline when <paramref name="when"/> returns <c>true</c>.
+	/// The sub-pipeline's final <see cref="Either{TError,TPayload}"/> state replaces the loop body state.
+	/// <para>On <c>Right</c>, predicate <c>true</c>: runs the sub-pipeline; its result becomes the new state.</para>
+	/// <para>On <c>Right</c>, predicate <c>false</c>: no-op, existing state passes through unchanged.</para>
+	/// <para>On <c>Left</c>: skips — predicate is not evaluated.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> Branch(
+		Func<TPayload, bool> when,
+		Action<BranchBuilder<TPayload, TError>> branch)
+	{
+		var branchBuilder = new BranchBuilder<TPayload, TError>();
+		branch(branchBuilder);
+		var branchOps = branchBuilder.Operators;
+
+		Operators.Add(async (current, _, ct) =>
+		{
+			if (!current.IsRight) return current;
+			if (!when(current.Right!)) return current;
+
+			var branchCurrent = current;
+			var branchLastRight = current.Right!;
+			foreach (var op in branchOps)
+			{
+				if (branchCurrent.IsRight) branchLastRight = branchCurrent.Right!;
+				branchCurrent = await op(branchCurrent, branchLastRight, ct);
+			}
+			return branchCurrent;
+		});
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a business-rule enforcement operator. When <paramref name="when"/> returns <c>true</c>
+	/// the rail remains <c>Right(payload)</c> unchanged. When <paramref name="when"/> returns <c>false</c>
+	/// the rail transitions to <c>Left(failWith(payload))</c>.
+	/// <para>On <c>Left</c>: passes through without evaluating <paramref name="when"/> or <paramref name="failWith"/>.</para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> Ensure(Func<TPayload, bool> when, Func<TPayload, TError> failWith)
+	{
+		Operators.Add((current, _, _ct) =>
+		{
+			if (!current.IsRight) return Task.FromResult(current);
+			var payload = current.Right!;
+			return Task.FromResult(!when(payload)
+				? Either<TError, TPayload>.FromLeft(failWith(payload))
+				: current);
+		});
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a typed synchronous recovery operator. When the rail is <c>Left</c> and the error value
+	/// is assignable to <typeparamref name="TErr"/>, the <paramref name="handler"/> runs and
+	/// its returned payload becomes the new <c>Right</c>.
+	/// Non-matching <c>Left</c> values and <c>Right</c> values pass through unchanged.
+	/// The handler receives the pre-failure payload snapshot for this iteration.
+	/// <para>
+	/// Recovery is scoped to the current iteration: a <c>Recover</c> inside the body catches only
+	/// <c>Left</c> values produced by earlier operators in the same iteration.
+	/// </para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> Recover<TErr>(Func<TErr, TPayload, TPayload> handler)
+	{
+		Operators.Add((current, lastRight, _ct) =>
+		{
+			if (!current.IsLeft) return Task.FromResult(current);
+			if (current.Left is TErr err)
+				return Task.FromResult(Either<TError, TPayload>.FromRight(handler(err, lastRight)));
+			return Task.FromResult(current);
+		});
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a typed asynchronous recovery operator. When the rail is <c>Left</c> and the error value
+	/// is assignable to <typeparamref name="TErr"/>, the <paramref name="handler"/> runs and
+	/// its returned payload becomes the new <c>Right</c>.
+	/// Non-matching <c>Left</c> values and <c>Right</c> values pass through unchanged.
+	/// The handler receives the pre-failure payload snapshot for this iteration.
+	/// <para>
+	/// Recovery is scoped to the current iteration: a <c>Recover</c> inside the body catches only
+	/// <c>Left</c> values produced by earlier operators in the same iteration.
+	/// </para>
+	/// </summary>
+	public LoopBuilder<TPayload, TError> Recover<TErr>(Func<TErr, TPayload, CancellationToken, Task<TPayload>> handler)
+	{
+		Operators.Add(async (current, lastRight, ct) =>
+		{
+			if (!current.IsLeft) return current;
+			if (current.Left is TErr err)
+				return Either<TError, TPayload>.FromRight(await handler(err, lastRight, ct));
+			return current;
+		});
+		return this;
+	}
+}

--- a/Zooper.Bee/RailwayStepsBuilder.cs
+++ b/Zooper.Bee/RailwayStepsBuilder.cs
@@ -399,6 +399,158 @@ public sealed class RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError>
     }
 
     /// <summary>
+    /// Executes a bounded iteration on the right rail.
+    /// <para>
+    /// When the rail is <c>Right(payload)</c>, runs <paramref name="body"/> repeatedly
+    /// until <paramref name="until"/> returns <c>true</c> or <paramref name="maxAttempts"/>
+    /// iterations have been exhausted without <paramref name="until"/> being satisfied.
+    /// </para>
+    /// <para><strong>Iteration order per attempt (1-indexed):</strong></para>
+    /// <list type="number">
+    ///   <item>Run the body. If the body returns <c>Left</c>, the loop exits immediately with that <c>Left</c>.</item>
+    ///   <item>Evaluate <paramref name="until"/>. If <c>true</c>, exit with <c>Right(payload)</c>.</item>
+    ///   <item>If <c>attempt == maxAttempts</c>, exit with <c>Left(exhausted(payload, attempt))</c>.</item>
+    ///   <item>Apply <paramref name="mutate"/> (if provided) to produce the starting payload for the next iteration.</item>
+    ///   <item>Advance to the next iteration.</item>
+    /// </list>
+    /// <para><strong>Left passthrough:</strong> when the rail is <c>Left</c> at the start of <c>Loop</c>,
+    /// the <c>Left</c> passes through unchanged; <paramref name="body"/>, <paramref name="until"/>,
+    /// <paramref name="mutate"/>, and <paramref name="exhausted"/> are not invoked.</para>
+    /// <para><strong>mutate cannot fail the rail:</strong> <paramref name="mutate"/> is a pure payload
+    /// transform. Fallible work should be expressed as a <c>Do</c> at the start of the next body.</para>
+    /// <para><strong>Recover scoping:</strong> a <c>Recover</c> inside the body is scoped to errors raised
+    /// within the same iteration. A <c>Left</c> not caught by a body-level <c>Recover</c> exits the entire loop.</para>
+    /// <para><strong>exhausted is the caller's delegate:</strong> no default error is provided because
+    /// <typeparamref name="TError"/> is open; the caller chooses what <c>Left</c> represents exhaustion.</para>
+    /// </summary>
+    /// <param name="body">Configures the inner sub-pipeline that runs on each iteration.</param>
+    /// <param name="until">Break condition evaluated after each iteration; receives <c>(payload, attempt)</c>. Loop exits <c>Right</c> when <c>true</c>.</param>
+    /// <param name="maxAttempts">Hard upper bound on iterations. Must be <c>&gt;= 1</c>.</param>
+    /// <param name="exhausted">Produces the <c>Left</c> value when <paramref name="maxAttempts"/> is reached without <paramref name="until"/> being satisfied.</param>
+    /// <param name="mutate">Optional inter-iteration payload transform applied after <paramref name="until"/> is <c>false</c> and before the next iteration. Never runs before the first iteration or after the loop exits.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown at registration time when <paramref name="maxAttempts"/> is less than 1.</exception>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Loop(
+        Action<LoopBuilder<TPayload, TError>> body,
+        Func<TPayload, int, bool> until,
+        int maxAttempts,
+        Func<TPayload, int, TError> exhausted,
+        Func<TPayload, int, TPayload>? mutate = null)
+    {
+        if (maxAttempts < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxAttempts), maxAttempts,
+                "maxAttempts must be >= 1.");
+
+        // Lift sync delegates to async so we share one core implementation.
+        Func<TPayload, int, CancellationToken, Task<bool>> untilAsync =
+            (p, a, _) => Task.FromResult(until(p, a));
+        Func<TPayload, int, CancellationToken, Task<TError>> exhaustedAsync =
+            (p, a, _) => Task.FromResult(exhausted(p, a));
+        Func<TPayload, int, CancellationToken, Task<TPayload>>? mutateAsync =
+            mutate == null ? null : (TPayload p, int a, CancellationToken _) => Task.FromResult(mutate(p, a));
+
+        return LoopCore(body, untilAsync, maxAttempts, exhaustedAsync, mutateAsync);
+    }
+
+    /// <summary>
+    /// Executes a bounded iteration on the right rail using asynchronous hooks.
+    /// <para>
+    /// When the rail is <c>Right(payload)</c>, runs <paramref name="body"/> repeatedly
+    /// until <paramref name="until"/> returns <c>true</c> or <paramref name="maxAttempts"/>
+    /// iterations have been exhausted without <paramref name="until"/> being satisfied.
+    /// </para>
+    /// <para><strong>Iteration order per attempt (1-indexed):</strong></para>
+    /// <list type="number">
+    ///   <item>Run the body. If the body returns <c>Left</c>, the loop exits immediately with that <c>Left</c>.</item>
+    ///   <item>Evaluate <paramref name="until"/>. If <c>true</c>, exit with <c>Right(payload)</c>.</item>
+    ///   <item>If <c>attempt == maxAttempts</c>, exit with <c>Left(exhausted(payload, attempt))</c>.</item>
+    ///   <item>Apply <paramref name="mutate"/> (if provided) to produce the starting payload for the next iteration.</item>
+    ///   <item>Advance to the next iteration.</item>
+    /// </list>
+    /// <para><strong>Left passthrough:</strong> when the rail is <c>Left</c> at the start of <c>Loop</c>,
+    /// the <c>Left</c> passes through unchanged; <paramref name="body"/>, <paramref name="until"/>,
+    /// <paramref name="mutate"/>, and <paramref name="exhausted"/> are not invoked.</para>
+    /// <para><strong>CancellationToken:</strong> the token is threaded into all async delegates.
+    /// <c>OperationCanceledException</c> propagates from the body per existing executor behaviour.</para>
+    /// <para><strong>Mixed sync/async:</strong> to combine a sync hook with async ones, pass the async
+    /// overload directly and wrap sync values in <c>Task.FromResult</c>.</para>
+    /// <para><strong>mutate cannot fail the rail:</strong> <paramref name="mutate"/> is a pure payload
+    /// transform. Fallible work should be expressed as a <c>Do</c> at the start of the next body.</para>
+    /// <para><strong>Recover scoping:</strong> a <c>Recover</c> inside the body is scoped to errors raised
+    /// within the same iteration. A <c>Left</c> not caught by a body-level <c>Recover</c> exits the entire loop.</para>
+    /// <para><strong>exhausted is the caller's delegate:</strong> no default error is provided because
+    /// <typeparamref name="TError"/> is open; the caller chooses what <c>Left</c> represents exhaustion.</para>
+    /// </summary>
+    /// <param name="body">Configures the inner sub-pipeline that runs on each iteration.</param>
+    /// <param name="until">Async break condition evaluated after each iteration; receives <c>(payload, attempt, ct)</c>. Loop exits <c>Right</c> when <c>true</c>.</param>
+    /// <param name="maxAttempts">Hard upper bound on iterations. Must be <c>&gt;= 1</c>.</param>
+    /// <param name="exhausted">Async delegate that produces the <c>Left</c> value when <paramref name="maxAttempts"/> is reached without <paramref name="until"/> being satisfied.</param>
+    /// <param name="mutate">Optional async inter-iteration payload transform. Never runs before the first iteration or after the loop exits.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown at registration time when <paramref name="maxAttempts"/> is less than 1.</exception>
+    public RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> Loop(
+        Action<LoopBuilder<TPayload, TError>> body,
+        Func<TPayload, int, CancellationToken, Task<bool>> until,
+        int maxAttempts,
+        Func<TPayload, int, CancellationToken, Task<TError>> exhausted,
+        Func<TPayload, int, CancellationToken, Task<TPayload>>? mutate = null)
+    {
+        if (maxAttempts < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxAttempts), maxAttempts,
+                "maxAttempts must be >= 1.");
+
+        return LoopCore(body, until, maxAttempts, exhausted, mutate);
+    }
+
+    private RailwayStepsBuilder<TRequest, TPayload, TSuccess, TError> LoopCore(
+        Action<LoopBuilder<TPayload, TError>> body,
+        Func<TPayload, int, CancellationToken, Task<bool>> until,
+        int maxAttempts,
+        Func<TPayload, int, CancellationToken, Task<TError>> exhausted,
+        Func<TPayload, int, CancellationToken, Task<TPayload>>? mutate)
+    {
+        var loopBuilder = new LoopBuilder<TPayload, TError>();
+        body(loopBuilder);
+        var loopOps = loopBuilder.Operators;
+
+        _operators.Add(async (current, _, ct) =>
+        {
+            // Left passthrough: do not invoke any loop hook.
+            if (!current.IsRight) return current;
+
+            var state = current.Right!;
+
+            for (var attempt = 1; ; attempt++)
+            {
+                // 1. Run the body on a fresh Right(state) for this iteration.
+                var bodyCurrent = Either<TError, TPayload>.FromRight(state);
+                var bodyLastRight = state;
+                foreach (var op in loopOps)
+                {
+                    if (bodyCurrent.IsRight) bodyLastRight = bodyCurrent.Right!;
+                    bodyCurrent = await op(bodyCurrent, bodyLastRight, ct);
+                }
+
+                // 2. Body short-circuit: exit immediately with the Left.
+                if (!bodyCurrent.IsRight) return bodyCurrent;
+
+                state = bodyCurrent.Right!;
+
+                // 3. Check break condition.
+                if (await until(state, attempt, ct))
+                    return Either<TError, TPayload>.FromRight(state);
+
+                // 4. Check exhaustion (mutate does NOT run after the final iteration).
+                if (attempt == maxAttempts)
+                    return Either<TError, TPayload>.FromLeft(await exhausted(state, attempt, ct));
+
+                // 5. Inter-iteration mutation.
+                if (mutate != null)
+                    state = await mutate(state, attempt, ct);
+            }
+        });
+        return this;
+    }
+
+    /// <summary>
     /// Builds and returns the configured <see cref="Railway{TRequest,TSuccess,TError}"/> ready for execution.
     /// </summary>
     public Railway<TRequest, TSuccess, TError> Build() => new(ExecuteRailwayAsync);

--- a/openspec/changes/add-railway-loops/.openspec.yaml
+++ b/openspec/changes/add-railway-loops/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-31

--- a/openspec/changes/add-railway-loops/design.md
+++ b/openspec/changes/add-railway-loops/design.md
@@ -1,0 +1,167 @@
+## Context
+
+`railway-vnext` introduces an Either-flowing step executor where each operator is modelled as a `Func<Either<TError, TPayload>, CancellationToken, Task<Either<TError, TPayload>>>`. `Branch` is the closest existing precedent for what `Loop` needs: a nested right-side sub-pipeline that runs conditionally, with its inner builder exposing a curated subset of operators and producing an `Either` that replaces the rail state.
+
+There is currently no way to express bounded iteration inside a railway. Authors who need "poll until ready" or "retry with mutated input" either wrap the railway in an external `while`, write recursive `Do` helpers, or shell out to ad-hoc retry libraries. All three hide iteration intent from the DSL and from the railway's reading order.
+
+`Loop` is additive to the vNext operator set. The executor rewrite from `railway-vnext` (Decision 1) already supports treating any operator as an Either-transformer, so `Loop` slots in as one more transformer — it does not require a second executor rewrite.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- First-class bounded iteration on the right rail with a break condition, a hard attempt cap, and an inter-iteration mutation hook.
+- Reads like the rest of the vNext DSL: `Loop(body: …, until: …, maxAttempts: …, mutate: …)` matches the named-parameter style of `Branch` and `Ensure`.
+- Nested right-side operators inside the body (`Do`, `Tap`, `Effects`, `TryTap`, `TryEffects`, `Branch`, `Ensure`, `Recover`) work exactly as they do at the top level, scoped to the current iteration.
+- Exhaustion is expressed on the rail, not as an exception: hitting `maxAttempts` without `until` becoming true produces a caller-defined `Left`.
+- `Left` semantics from `railway-step-operators` are preserved: a `Left` raised inside the body short-circuits the loop (caller can wrap critical sections in `Recover` to keep iterating).
+
+**Non-Goals:**
+
+- Backoff, jitter, or delay between iterations. The first iteration of `Loop` is a control-flow primitive, not a retry policy library. Delays can be added inside the body via an async `Do`/`Tap` if needed.
+- Unbounded loops (`maxAttempts` optional / null). All loops must be bounded.
+- Nested `Loop` inside `Loop`. Same readability rationale as nested `Branch` (vNext Decision 5).
+- `Loop` inside `Branch` body or `Loop` body — out of scope for v1; the inner builders do not expose `Loop`.
+- `Detach` or `Finally` inside `Loop` body. Lifecycle concerns belong at the top level.
+- Concurrent iterations or fan-out. `Loop` is strictly sequential.
+- Parallel execution of multiple iterations.
+
+## Decisions
+
+### Decision 1: `Loop` is a single transformer that drives its body N times
+
+`Loop` registers as one Either-transformer in the parent operator list. Internally the transformer compiles its body once into a nested transformer chain (matching how `Branch` compiles its `BranchBuilder`) and then runs that chain in a sequential loop driven by the loop's own controller. The parent executor is unaware of iteration — it sees a single operator that consumes an `Either` and produces an `Either`.
+
+**Why over "expand body into the parent list N times":** the body is dynamic in length (iteration count depends on runtime state). Static expansion is impossible. Treating `Loop` as a single transformer also matches the `Branch` precedent and keeps registration order preserved at the parent level.
+
+**Alternatives considered:**
+
+- *Special-case the executor to understand iteration*: bloats the executor with one more operator-aware code path. Rejected for the same reason `Recover` is operator-local, not executor-local (vNext Decision 1).
+- *Build `Loop` on top of recursion at the call site*: would make iteration invisible to the DSL — the explicit goal this change exists to fix.
+
+### Decision 2: Iteration semantics
+
+Pseudocode (sync form; async is identical with `await`):
+
+```
+attempt = 1
+state = incomingRight   // pre-failure payload snapshot
+loop:
+    result = runBody(Right(state))
+    if result is Left(err):
+        return Left(err)                          // body short-circuit
+    state = result.RightValue
+    if until(state, attempt) == true:
+        return Right(state)                       // break condition met
+    if attempt == maxAttempts:
+        return Left(exhausted(state, attempt))    // exhaustion → caller-defined Left
+    state = mutate(state, attempt)                // inter-iteration mutation
+    attempt = attempt + 1
+    goto loop
+```
+
+`mutate` only runs **between** iterations — never before the first, never after the loop exits. `until` runs after each iteration. `exhausted` runs at most once, only when the cap is hit.
+
+**Why `until` after the body (not before):** the natural reading is "do work, then check if we're done." A pre-check (`while(until is false)`) would require running `until` against the incoming payload, which may not have the loop-relevant fields populated yet. Authors who want a pre-check can start the body with `Ensure(when: …, failWith: …)` or place the check inside the body.
+
+### Decision 3: Signature uses named parameters
+
+```csharp
+public RailwayStepsBuilder<…> Loop(
+    Action<LoopBuilder<TPayload, TError>> body,
+    Func<TPayload, int, bool> until,
+    int maxAttempts,
+    Func<TPayload, int, TError> exhausted,
+    Func<TPayload, int, TPayload>? mutate = null);
+```
+
+Async overloads mirror this with `Func<TPayload, int, CancellationToken, Task<bool>>`, `Func<TPayload, int, CancellationToken, Task<TError>>`, and `Func<TPayload, int, CancellationToken, Task<TPayload>>`.
+
+- `attempt` is 1-indexed (matches "first attempt" / "max attempts" mental model).
+- `mutate` is optional — pure polling loops have no mutation.
+- `exhausted` is **required**. There is no library-default error type because `TError` is open; the caller chooses what `Left` they want.
+- `maxAttempts` is required and must be `>= 1`. Constructor validates this and throws `ArgumentOutOfRangeException` at registration time.
+
+**Why `exhausted` is a delegate, not a constant:** the exhaustion error often wants to carry the last observed payload state (e.g., `LoopExhaustedError(planetId: payload.PlanetId, attempts: 5)`). A `TError` constant cannot capture iteration-local data.
+
+**Why `attempt` is exposed:** loops that mutate based on iteration index (e.g., increment a retry counter, swap a strategy) need it. Passing it explicitly is clearer than asking authors to thread it through the payload.
+
+**Alternatives considered:**
+
+- *Pre-check semantics (`while`)*: rejected — see Decision 2.
+- *Library-defined `LoopExhaustedError`*: would require `TError` to inherit a common base or implement an interface, breaking the open-`TError` contract. Rejected.
+- *`mutate` returns `Either<TError, TPayload>` (fallible mutation)*: rejected. Mutation is a payload tweak; if it can fail, model it as an inner `Do` at the start of the next body rather than a separate failable hook. Keeps the loop primitive simple.
+
+### Decision 4: `LoopBuilder` allowed operators
+
+`LoopBuilder<TPayload, TError>` exposes:
+
+- `Do` (sync + async)
+- `Tap` (all three overloads from vNext)
+- `Effects` / `TryEffects`
+- `TryTap`
+- `Branch`
+- `Ensure`
+- `Recover<TErr>`
+
+It does **not** expose: `Loop` (no nesting), `Detach` (lifecycle), `Finally` (lifecycle).
+
+**Why the same set as `BranchBuilder` plus `Branch`:** inside a loop iteration, all the right-side operators that make sense in a branch also make sense in a loop body. Branch is included because conditional behaviour inside an iteration is a common pattern (e.g., "if the response is partial, run one extra step"). The vNext convention that `BranchBuilder` does not expose `Branch` is a per-builder choice for readability — `LoopBuilder` is a separate scope and benefits from `Branch`.
+
+**Why no nested `Loop`:** matches vNext Decision 5's rationale for forbidding nested `Branch`. Authors who genuinely need nested iteration can extract the inner pipeline into a helper that builds and runs its own railway, or revisit when v2 has more evidence.
+
+### Decision 5: `Recover` inside the body is scoped to the current iteration
+
+`Recover<TErr>` registered inside the body catches `Left`s produced by earlier operators **in the same iteration**. A `Left` raised in iteration *N* that is not caught by a `Recover` in the body exits the entire loop with that `Left` — it does not "carry over" to iteration *N+1*.
+
+This is a direct consequence of Decision 1 + Decision 2: each iteration runs the compiled body chain end-to-end on a fresh `Right(state)`. The Either threaded through one iteration is independent of the next.
+
+**Why this scoping:** any other rule would either (a) require the loop to inspect operator types inside the body (breaks executor opacity from vNext Decision 1) or (b) introduce a second kind of recovery that spans iterations — which is the caller's job to express by putting `Recover` inside the body.
+
+**Consequence:** "keep retrying despite errors of type `TErr`" is expressed as `Loop(body: b => b.Do(risky).Recover<TErr>(fallback), until: …, maxAttempts: …)`. The `Recover` converts the iteration's `Left` back to `Right`, the loop continues, and `mutate` (if set) gets to adjust for the next attempt.
+
+### Decision 6: Payload snapshot semantics
+
+When the loop transformer is invoked, the incoming rail is either `Right(p)` or `Left(e)`.
+
+- `Left(e)` → the loop passes through unchanged; `body`, `until`, `mutate`, `exhausted` are not invoked. Matches every other right-side operator.
+- `Right(p)` → `p` is the starting state for iteration 1.
+
+The body's inner executor follows the same payload-snapshot rules as the top-level executor (vNext Decision 7 / 8): each inner operator snapshots the last `Right` payload before running so that inner `Recover` handlers receive the pre-failure payload. The loop controller observes only the final `Either` from each iteration; it does not see intermediate snapshots inside the body.
+
+### Decision 7: Cancellation propagates without special handling
+
+The `CancellationToken` is threaded into `body`, `until`, `mutate`, and `exhausted` (async overloads). If the token is cancelled mid-iteration, `body` raises `OperationCanceledException` per existing executor behaviour — the loop transformer does not catch it. Cancellation between iterations (after `mutate`, before next `body` start) is the caller's responsibility to honour inside async delegates.
+
+**Why no explicit "cancellation = exit with Left":** cancellation has uniform semantics in vNext (exception propagates). Special-casing inside `Loop` would diverge from that contract.
+
+### Decision 8: API additions are non-breaking
+
+Adding `Loop(...)` overloads to `RailwayStepsBuilder<...>` is purely additive. No existing operator changes. `Loop` is not added to `BranchBuilder` (per Decision 4). The capability delta for `railway-step-operators` adds `Loop` to the "registration order is preserved" requirement and the operator inventory, but does not modify or remove any existing requirement.
+
+## Risks / Trade-offs
+
+- **Infinite loop bug despite the cap** → A `maxAttempts` of `int.MaxValue` combined with a slow body is still effectively infinite. *Mitigation:* document that `maxAttempts` is a hard cap, not a "reasonable" cap; recommend explicit small numbers (typical: 3–10) in the docs. No runtime ceiling — the caller owns the cap.
+- **`mutate` mistaken as a fallible step** → Callers may try to put real side effects with failure semantics inside `mutate`. *Mitigation:* docs and the operator name reinforce that `mutate` is a pure payload transform. Fallible work goes into the body as `Do` / `Tap`.
+- **`Recover`-inside-`Loop` confusion** → Some authors will expect a top-level `Recover` after a `Loop` to catch errors from *individual iterations*. It will not — it catches the loop's final `Left` (either body short-circuit or exhaustion). *Mitigation:* docs include a worked example of "recover per-iteration vs. recover post-loop"; tests cover both shapes.
+- **No nested `Loop`** → Some use cases (matrix retry: outer "strategies", inner "attempts per strategy") cannot be expressed in v1. *Mitigation:* document the limitation. If demand is real, lift in v2 once the v1 shape is settled.
+- **Iteration count drift between `until`/`mutate`/`exhausted`** → The contract says `until` and `exhausted` see `attempt = N` for iteration `N`, and `mutate` sees `attempt = N` while preparing iteration `N+1`. Off-by-one bugs here would be silent. *Mitigation:* explicit test for "attempt indices match across all three hooks" and a worked example in `Zooper.Bee.Example`.
+- **Sync/async overload explosion** → Three hooks × two arities (sync/async) × overloads = many method signatures. *Mitigation:* generate the matrix once in the builder; document that the async forms accept any combination (sync `until` with async `mutate`, etc.).
+
+## Migration Plan
+
+`Loop` is additive. No migration is required for existing railways.
+
+- Land alongside `railway-vnext` (depends on the executor rewrite from that change). If `railway-vnext` archives first, this change applies cleanly. If both are in flight simultaneously, the implementer should rebase this change onto vNext's executor types.
+- Ship in the next minor release after vNext (which is `4.0.0`). `Loop` lands in `4.1.0` unless explicitly held back.
+- Update `Zooper.Bee.Example` with one loop sample (recommended: poll-for-ready, since it exercises `until` without `mutate`).
+- `CHANGELOG.md` `## [Unreleased]` entry highlights `Loop` and links to the sample.
+- No rollback strategy needed — additive operator.
+
+## Open Questions
+
+- **`exhausted` ergonomics** — required delegate vs. optional with a library-defined `LoopExhaustedError<TPayload>` (would require widening `TError` constraints). Current design: required delegate, no constraint. Confirm.
+- **Per-iteration timing/observability hook** — should `Loop` expose an optional `onIteration(payload, attempt)` callback for logging without forcing the author to put a `Tap` inside the body? Current design: no, use `Tap` inside the body. Confirm.
+- **`mutate` running on the last iteration** — current design says `mutate` does **not** run after the final iteration even if exhaustion is about to fire. Confirm this is the right call (vs. "always mutate after a Right that doesn't satisfy until").
+- **Empty body** — `Loop(body: _ => {}, until: …, …)` would spin maxAttempts times calling only `until` and `mutate`. Allow or reject at registration? Current design: allow (caller may want a pure until-poll over an externally-mutated payload via `mutate`). Confirm.
+- **`maxAttempts = 1` semantics** — equivalent to "run body once, check until, exit with Right if true or Left(exhausted) if false." Useful as a degenerate case or confusing? Current design: allowed. Confirm.

--- a/openspec/changes/add-railway-loops/proposal.md
+++ b/openspec/changes/add-railway-loops/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Bee railways currently express linear progression and conditional branches, but have no first-class operator for iterative work — retrying a step until a condition holds, polling for readiness, or attempting a fallible operation with mutated inputs across attempts. Authors today fake this with recursion, external `while` loops outside the railway, or by wrapping `Do` in custom retry helpers, all of which leave the iteration intent invisible to the railway DSL and break the "railway reads like a narrative" property that `railway-vnext` is establishing.
+
+## What Changes
+
+- Add `Loop(body, until:, maxAttempts:, mutate:)` operator to `RailwayStepsBuilder` for first-class bounded iteration on the right rail.
+- Loop body is a nested right-side sub-pipeline (`LoopBuilder<TPayload, TError>`) that supports `Do`, `Tap`, `Effects`, `TryTap`, `TryEffects`, `Branch`, `Ensure`, `Recover` — the same operators allowed inside `Branch`. `Detach`, `Finally`, and nested `Loop` are out of scope for the first iteration.
+- `until` is the break condition evaluated against the payload after each iteration; when `true`, the loop exits successfully on the `Right` rail.
+- `maxAttempts` is a required safety bound (positive integer). When exhausted without `until` becoming `true`, the loop produces a `Left` with a `LoopExhaustedError` (or library-defined equivalent) carrying the last payload and attempt count.
+- `mutate` is an optional payload transform applied between iterations to change inputs for the next attempt ("when still not working, change something in hopes it works now"). It runs after the body produces a `Right` and `until` is `false`, before the next iteration starts. `mutate` MUST NOT fail the rail.
+- A `Left` produced inside the loop body short-circuits the loop (consistent with `Branch`); the loop returns that `Left`. Recovery inside the body via `Recover<TErr>` can convert it back to `Right` and continue iterating.
+- Sync + async overloads for `until` and `mutate`, mirroring existing operators.
+- Update `Zooper.Bee.Example` with a representative loop use case (poll-for-ready or retry-with-mutation).
+- Update `CHANGELOG.md` `## [Unreleased]` entry.
+
+## Capabilities
+
+### New Capabilities
+
+- `railway-loops`: The `Loop` operator and its semantics — break condition (`until`), bounded attempts (`maxAttempts`), inter-iteration mutation (`mutate`), allowed nested operators, and exhaustion / short-circuit behavior.
+
+### Modified Capabilities
+
+- `railway-step-operators`: Add `Loop` to the registered operator set and the "registration order is preserved" guarantee. (Capability is introduced by the pending `railway-vnext` change; this delta layers on top.)
+
+## Impact
+
+- **Package `Zooper.Bee`**: New `LoopBuilder<TPayload, TError>` type. New `Loop(...)` overloads on `RailwayStepsBuilder<...>`. New `LoopExhaustedError` (or analogous) surfaced when `maxAttempts` is hit. Loop execution wired into the step executor in the same registration-order regime as `Branch`.
+- **Package `Zooper.Bee.Tests`**: New test suite covering: body executes once when `until` is immediately true; iterates up to `maxAttempts` and exits with `Left` on exhaustion; `mutate` runs between iterations only; `Left` inside body short-circuits; `Recover` inside body keeps the loop iterating; async overloads await correctly.
+- **Package `Zooper.Bee.Example`**: New sample railway using `Loop` (poll-until-ready or retry-with-mutation).
+- **Docs**: `CHANGELOG.md` (`Unreleased`) entry. `README.md` operator table updated to include `Loop`.
+- **Dependency**: this change layers on `railway-vnext`. If `railway-vnext` has not archived to `openspec/specs/` by the time this change is implemented, the modified-capability delta for `railway-step-operators` will be merged at archive time.
+- **No breaking changes**: `Loop` is purely additive to the vNext operator set.

--- a/openspec/changes/add-railway-loops/specs/railway-loops/spec.md
+++ b/openspec/changes/add-railway-loops/specs/railway-loops/spec.md
@@ -1,0 +1,190 @@
+## ADDED Requirements
+
+### Requirement: Loop Operator Drives a Bounded Iteration on the Right Rail
+
+The `RailwayStepsBuilder.Loop(body, until, maxAttempts, exhausted, mutate)` operator SHALL execute a nested right-side sub-pipeline (the body) repeatedly until either the break condition `until` becomes true or the cap `maxAttempts` is reached.
+
+When the rail is `Right(payload)`, the loop MUST run the body with `Right(payload)` as the starting state for iteration 1. When the rail is `Left`, the loop MUST pass the `Left` through unchanged and MUST NOT evaluate `body`, `until`, `mutate`, or `exhausted`.
+
+The builder SHALL expose synchronous and asynchronous overloads. The asynchronous overload's `until`, `mutate`, and `exhausted` delegates MUST receive the `CancellationToken` of the surrounding railway execution.
+
+#### Scenario: Loop passes through an incoming Left
+
+- **WHEN** the rail is `Left(error)` at the start of a `Loop`
+- **THEN** the rail after the operator is `Left(error)`
+- **AND** the body is not executed
+- **AND** `until`, `mutate`, and `exhausted` are not invoked
+
+#### Scenario: Loop starts iteration 1 with the incoming Right payload
+
+- **WHEN** the rail is `Right(p0)` at the start of a `Loop`
+- **THEN** the body's first iteration runs with `Right(p0)`
+- **AND** the body sees `p0` as its starting payload
+
+### Requirement: Loop Iteration Order — Body, Until, Exhaustion Check, Mutate
+
+For each iteration `N` (1-indexed), the loop MUST perform the following operations in this exact order:
+
+1. Run the body with the current right-side state.
+2. If the body's result is `Left(err)`, exit the loop with `Left(err)` immediately and do not evaluate `until`, `exhausted`, or `mutate`.
+3. Otherwise, evaluate `until(payload, attempt = N)` against the body's resulting payload. If `until` returns `true`, exit the loop with `Right(payload)`.
+4. If `until` is `false` and `N == maxAttempts`, exit the loop with `Left(exhausted(payload, attempt = N))`.
+5. Otherwise, evaluate `mutate(payload, attempt = N)` (if provided) to produce the starting payload for iteration `N+1`. If `mutate` is not provided, the starting payload for iteration `N+1` is the body's output payload unchanged.
+
+`mutate` MUST NOT run before iteration 1 starts. `mutate` MUST NOT run after the loop has decided to exit (either via `until` or exhaustion). `exhausted` MUST run at most once per `Loop` invocation, and only when the cap has been reached without `until` being satisfied.
+
+#### Scenario: Loop exits on Right when until is true after the first iteration
+
+- **WHEN** the body of iteration 1 returns `Right(p1)` and `until(p1, 1)` returns `true`
+- **THEN** the rail after the loop is `Right(p1)`
+- **AND** `mutate` is not invoked
+- **AND** `exhausted` is not invoked
+- **AND** no further iterations run
+
+#### Scenario: Loop runs mutate between iterations only
+
+- **WHEN** the body of iteration 1 returns `Right(p1)`, `until(p1, 1)` returns `false`, `mutate(p1, 1)` returns `p1m`, and `maxAttempts >= 2`
+- **THEN** iteration 2's body starts with `Right(p1m)`
+- **AND** `mutate` is invoked exactly once with `(p1, 1)` between iterations 1 and 2
+
+#### Scenario: Loop with no mutate preserves the body output for the next iteration
+
+- **WHEN** the body of iteration 1 returns `Right(p1)`, `until(p1, 1)` returns `false`, no `mutate` is provided, and `maxAttempts >= 2`
+- **THEN** iteration 2's body starts with `Right(p1)`
+
+#### Scenario: until receives the body's output payload and the 1-indexed attempt number
+
+- **WHEN** the body of iteration `N` returns `Right(pN)`
+- **THEN** `until` is invoked with arguments `(pN, N)`
+- **AND** `until` is invoked exactly once per non-failing iteration
+
+### Requirement: Loop Exhaustion Produces a Caller-Defined Left
+
+When the loop reaches iteration `maxAttempts` and `until` is `false` at the end of that iteration, the loop MUST exit with `Left(exhausted(payload, maxAttempts))` where `payload` is the body's output payload from the final iteration. The `exhausted` delegate MUST be supplied by the caller; the library MUST NOT provide a default error value.
+
+`exhausted` MUST be invoked exactly once when exhaustion occurs, and MUST NOT be invoked when the loop exits on `until` or on a body `Left`.
+
+#### Scenario: Loop exhaustion produces Left via the exhausted delegate
+
+- **WHEN** `maxAttempts` is 3, every iteration's `until` returns `false`, and iteration 3's body returns `Right(p3)`
+- **THEN** the rail after the loop is `Left(exhausted(p3, 3))`
+- **AND** `exhausted` is invoked exactly once with `(p3, 3)`
+- **AND** `mutate` is not invoked after iteration 3
+
+#### Scenario: exhausted is not invoked when until is satisfied
+
+- **WHEN** the loop exits because `until` returns `true` in some iteration
+- **THEN** `exhausted` is not invoked
+
+#### Scenario: exhausted is not invoked when the body produces Left
+
+- **WHEN** the body of some iteration returns `Left(err)`
+- **THEN** `exhausted` is not invoked
+- **AND** the loop exits with `Left(err)`
+
+### Requirement: Loop Body Left Short-Circuits the Loop
+
+When the body of any iteration produces `Left(err)`, the loop MUST exit immediately with `Left(err)`. The loop MUST NOT advance to the next iteration. `until`, `exhausted`, and `mutate` MUST NOT be invoked when the body returns `Left`.
+
+A `Recover<TErr>` operator registered **inside** the body MAY catch the `Left` and convert it back to `Right` before the body completes; in that case the iteration ends on `Right` and the loop's normal post-body sequence (Decision: until → exhaust check → mutate) proceeds.
+
+#### Scenario: Body Left exits the loop without further iterations
+
+- **WHEN** iteration 2's body returns `Left(err)`
+- **THEN** the rail after the loop is `Left(err)`
+- **AND** iteration 3 does not run
+- **AND** `until`, `mutate`, and `exhausted` are not invoked for iteration 2
+
+#### Scenario: Recover inside the body keeps the loop iterating
+
+- **WHEN** iteration 2's body raises `Left(TimeoutError)` internally and a `Recover<TimeoutError>` inside the body converts it to `Right(p2)` before the body completes
+- **AND** `until(p2, 2)` returns `false` and `maxAttempts >= 3`
+- **THEN** iteration 3 runs with the payload produced by `mutate(p2, 2)` (or `p2` if no `mutate` is provided)
+- **AND** the loop has not exited
+
+### Requirement: LoopBuilder Allowed Operators
+
+The nested builder `LoopBuilder<TPayload, TError>` SHALL expose `Do`, `Tap`, `Effects`, `TryTap`, `TryEffects`, `Branch`, `Ensure`, and `Recover<TErr>`. It MUST NOT expose `Loop` (no nested loops), `Detach`, or `Finally`.
+
+Operators inside the body MUST preserve registration order and MUST behave exactly as their top-level counterparts within the scope of a single iteration. `Recover` inside the body is scoped to errors raised by operators that appear earlier in the same body during the same iteration.
+
+#### Scenario: LoopBuilder exposes the documented operator surface
+
+- **WHEN** code inside the body calls `Do`, `Tap`, `Effects`, `TryTap`, `TryEffects`, `Branch`, `Ensure`, or `Recover<TErr>`
+- **THEN** the code compiles
+
+#### Scenario: LoopBuilder does not expose Loop
+
+- **WHEN** code inside the body calls `.Loop(...)`
+- **THEN** the code fails to compile because `Loop` is not a member of `LoopBuilder`
+
+#### Scenario: LoopBuilder does not expose Detach
+
+- **WHEN** code inside the body calls `.Detach(...)`
+- **THEN** the code fails to compile because `Detach` is not a member of `LoopBuilder`
+
+#### Scenario: LoopBuilder does not expose Finally
+
+- **WHEN** code inside the body calls `.Finally(...)`
+- **THEN** the code fails to compile because `Finally` is not a member of `LoopBuilder`
+
+#### Scenario: Recover inside the body does not span iterations
+
+- **WHEN** iteration 1's body produces `Right(p1)` and iteration 2's body raises a `Left` that no `Recover` inside the body matches
+- **THEN** the loop exits with that `Left` after iteration 2
+- **AND** any `Recover` that succeeded in iteration 1 does not catch iteration 2's error
+
+### Requirement: Loop Requires a Positive maxAttempts
+
+The `Loop` operator SHALL require `maxAttempts >= 1`. A `maxAttempts` value less than 1 MUST be rejected at builder-registration time with `ArgumentOutOfRangeException`.
+
+There is no upper bound on `maxAttempts` other than the platform's `int` range. Authors are responsible for choosing reasonable values.
+
+#### Scenario: maxAttempts of zero is rejected at registration
+
+- **WHEN** code calls `.Loop(body, until, maxAttempts: 0, exhausted)`
+- **THEN** an `ArgumentOutOfRangeException` is thrown at builder registration time
+- **AND** the railway is not constructed
+
+#### Scenario: Negative maxAttempts is rejected at registration
+
+- **WHEN** code calls `.Loop(body, until, maxAttempts: -1, exhausted)`
+- **THEN** an `ArgumentOutOfRangeException` is thrown at builder registration time
+
+#### Scenario: maxAttempts of one is permitted
+
+- **WHEN** code calls `.Loop(body, until, maxAttempts: 1, exhausted)`
+- **THEN** the builder accepts the registration
+- **AND** at runtime the loop runs the body exactly once before either exiting on `until` or producing `Left(exhausted(payload, 1))`
+
+### Requirement: Loop Mutate Is a Pure Payload Transform
+
+The `mutate` delegate SHALL be a payload-to-payload transform whose only purpose is to prepare the input for the next iteration. `mutate` MUST NOT change the rail outcome (it does not produce `Left`). `mutate` MUST NOT be invoked when the loop has decided to exit.
+
+#### Scenario: mutate cannot fail the rail
+
+- **WHEN** a `Loop` is registered
+- **THEN** the `mutate` delegate's return type is `TPayload` (or `Task<TPayload>` in the async overload)
+- **AND** there is no overload of `mutate` that returns `Either<TError, TPayload>`
+
+#### Scenario: mutate is skipped on the iteration that exits the loop
+
+- **WHEN** iteration `N` returns `Right(pN)` and `until(pN, N)` returns `true`
+- **THEN** `mutate` is not invoked for iteration `N`
+
+#### Scenario: mutate is skipped on the exhausting iteration
+
+- **WHEN** iteration `maxAttempts` returns `Right(pN)` and `until(pN, maxAttempts)` returns `false`
+- **THEN** `mutate` is not invoked
+- **AND** the loop exits with `Left(exhausted(pN, maxAttempts))`
+
+### Requirement: Loop Preserves Outer Registration Order
+
+A `Loop` operator SHALL participate in the parent `RailwayStepsBuilder`'s registration-order guarantee as a single transformer. Operators registered before a `Loop` MUST execute before any body iteration begins; operators registered after a `Loop` MUST execute only after the loop has produced its final `Either`.
+
+#### Scenario: Operators surrounding Loop run in registration order
+
+- **WHEN** a railway registers `Do(a)`, `Loop(...)`, `Do(b)` in that order
+- **THEN** `Do(a)` runs to completion before any iteration of the loop starts
+- **AND** `Do(b)` runs only after the loop has produced its final `Either`
+- **AND** no operator inside the loop body runs outside its enclosing iteration

--- a/openspec/changes/add-railway-loops/specs/railway-step-operators/spec.md
+++ b/openspec/changes/add-railway-loops/specs/railway-step-operators/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Step Execution Preserves Registration Order
+
+The `RailwayStepsBuilder` SHALL execute every registered operator in the exact order it was added. This MUST hold uniformly for `Do`, `Tap`, `Effects`, `TryTap`, `TryEffects`, `Detach`, `Branch`, `Ensure`, `Recover`, and `Loop`. No operator category may be reordered relative to another.
+
+#### Scenario: Operators of different categories run in registration order
+
+- **WHEN** a railway registers `Do(a)`, `Tap(b)`, `Branch(…)`, `Ensure(…)`, `Do(c)` in that order
+- **THEN** at runtime the operators execute in exactly that order
+- **AND** no category is hoisted, deferred, or reordered
+
+#### Scenario: Loop participates in registration order as a single transformer
+
+- **WHEN** a railway registers `Do(a)`, `Loop(...)`, `Do(b)` in that order
+- **THEN** `Do(a)` runs to completion before the loop begins iterating
+- **AND** `Do(b)` runs only after the loop has produced its final `Either`
+- **AND** the loop is not reordered relative to surrounding operators

--- a/openspec/changes/add-railway-loops/tasks.md
+++ b/openspec/changes/add-railway-loops/tasks.md
@@ -1,0 +1,72 @@
+## 1. Loop Builder and Transformer
+
+- [x] 1.1 Add `LoopBuilder<TPayload, TError>` class in `Zooper.Bee` exposing `Do`, `Tap`, `Effects`, `TryTap`, `TryEffects`, `Branch`, `Ensure`, `Recover<TErr>` — omit `Loop`, `Detach`, `Finally`
+- [x] 1.2 Reuse the vNext Either-transformer compilation pipeline so a `LoopBuilder` compiles its operators into a single inner transformer chain (matching how `BranchBuilder` compiles)
+- [x] 1.3 Add an internal `LoopOperator` (or equivalent) that wraps the compiled body and drives the iteration controller as a single outer transformer
+- [x] 1.4 Validate `maxAttempts >= 1` at registration time; throw `ArgumentOutOfRangeException` with a clear message naming the parameter
+- [x] 1.5 Make `mutate` optional (nullable delegate); `until` and `exhausted` are required
+
+## 2. Loop Iteration Controller
+
+- [x] 2.1 Implement iteration order from the spec: body → check `until` → check exhaustion → run `mutate` → next iteration
+- [x] 2.2 Pass through incoming `Left` unchanged without invoking body, `until`, `mutate`, or `exhausted`
+- [x] 2.3 Short-circuit on body `Left`: exit loop immediately with that `Left`, skip `until`, `mutate`, `exhausted`
+- [x] 2.4 On `until == true`, exit with `Right(payload)` and skip both `mutate` and `exhausted`
+- [x] 2.5 On reaching iteration `maxAttempts` with `until == false`, exit with `Left(exhausted(payload, maxAttempts))`; do not run `mutate` after the final iteration
+- [x] 2.6 Use 1-indexed attempt numbers; pass `attempt` to `until`, `mutate`, and `exhausted` consistently
+- [x] 2.7 Each iteration runs the compiled body chain end-to-end on a fresh `Right(state)` so inner `Recover` is scoped to that iteration only
+- [x] 2.8 Thread `CancellationToken` into async overloads of `until`, `mutate`, and `exhausted`; let `OperationCanceledException` propagate from the body per existing executor behaviour
+
+## 3. RailwayStepsBuilder API Surface
+
+- [x] 3.1 Add the sync `Loop(...)` overload to `RailwayStepsBuilder<...>` with `Func<TPayload, int, bool> until`, `Func<TPayload, int, TError> exhausted`, optional `Func<TPayload, int, TPayload> mutate`
+- [x] 3.2 Add the async `Loop(...)` overload with `Func<TPayload, int, CancellationToken, Task<bool>>`, `Func<TPayload, int, CancellationToken, Task<TError>>`, optional `Func<TPayload, int, CancellationToken, Task<TPayload>>`
+- [x] 3.3 Allow mixed sync/async hooks by providing internal adapters (e.g. sync `until` lifted to a completed `Task<bool>`) so callers can combine them without overload explosion
+- [x] 3.4 Add XML docs covering: right-rail behaviour, left-passthrough, iteration order, the role of each hook, that `mutate` cannot fail the rail, that exhaustion uses the caller's delegate
+- [x] 3.5 Confirm `Loop` is NOT exposed on `BranchBuilder` or `LoopBuilder` (no nested loops, no loops inside branch bodies for v1)
+
+## 4. Tests
+
+- [x] 4.1 Body short-circuit: iteration 2 returns `Left(err)` → loop exits `Left(err)`, iteration 3 does not run, `until`/`mutate`/`exhausted` not invoked
+- [x] 4.2 Break on `until`: iteration 1 returns `Right(p1)`, `until(p1, 1) == true` → loop exits `Right(p1)`, `mutate` and `exhausted` not invoked
+- [x] 4.3 Exhaustion: `maxAttempts = 3`, every `until` returns false, iteration 3 returns `Right(p3)` → loop exits `Left(exhausted(p3, 3))`, `mutate` not invoked after iteration 3
+- [x] 4.4 Mutate between iterations: iteration 1 returns `Right(p1)`, `mutate(p1, 1) → p1m` → iteration 2 starts with `Right(p1m)`
+- [x] 4.5 No-mutate path: when `mutate` is null and iteration 1 returns `Right(p1)` with `until == false`, iteration 2 starts with `Right(p1)`
+- [x] 4.6 Incoming `Left` passthrough: rail is `Left(err)` at start of `Loop` → no hooks invoked, rail unchanged
+- [x] 4.7 `maxAttempts = 1` runs body once; if `until == false`, exits `Left(exhausted(...))`; if `until == true`, exits `Right`
+- [x] 4.8 `maxAttempts = 0` and negative values throw `ArgumentOutOfRangeException` at registration
+- [x] 4.9 Empty body (`Loop(body: _ => {}, ...)`) is allowed; behaves as a pure poll over an externally-mutated payload
+- [x] 4.10 `Recover<TErr>` inside body converts iteration N's `Left` to `Right` → loop continues to iteration N+1 with mutate applied
+- [x] 4.11 `Recover` inside body in iteration 1 does NOT catch an uncaught `Left` raised in iteration 2 (per-iteration recovery scope)
+- [x] 4.12 Attempt index consistency: `until`, `mutate`, and `exhausted` all see the expected `attempt` number for the iteration they correspond to
+- [x] 4.13 Async hooks: all async overloads of `until`, `mutate`, `exhausted` are awaited; cancellation token is propagated
+- [x] 4.14 Mixed sync/async hooks compile and execute (e.g., sync `until` with async `mutate`)
+- [x] 4.15 Operators surrounding `Loop` run in registration order: `Do(a)` completes before loop begins; `Do(b)` runs only after loop completes
+- [x] 4.16 `LoopBuilder` exposes `Do`, `Tap`, `Effects`, `TryTap`, `TryEffects`, `Branch`, `Ensure`, `Recover` (positive compile test)
+- [x] 4.17 `LoopBuilder` does NOT expose `Loop`, `Detach`, `Finally` (negative compile assertion — separate assembly or `// @compile-fail` style harness if available, otherwise documented)
+- [x] 4.18 Inner `Branch` inside `Loop` body works as expected: branch body runs conditionally per iteration
+
+## 5. Example Project
+
+- [x] 5.1 Add a poll-for-ready sample to `Zooper.Bee.Example` using `Loop` with `until`, no `mutate`
+- [x] 5.2 Add a retry-with-mutation sample using `Loop` with all four hooks (`body`, `until`, `mutate`, `exhausted`) — demonstrate `Recover` inside the body to keep iterating despite transient failures
+- [x] 5.3 Verify both samples build and run
+
+## 6. MediatR Package Alignment
+
+- [x] 6.1 Audit `Zooper.Bee.MediatR` — no API breaks expected since `Loop` is additive; confirm build still passes
+- [x] 6.2 Run `Zooper.Bee.MediatR` tests against the new `Zooper.Bee`
+
+## 7. Docs and Changelog
+
+- [x] 7.1 Add `Loop` to `README.md` operator list and table; include one short code example
+- [x] 7.2 Update `CHANGELOG.md` `## [Unreleased]` — under `### Added`: `Loop(body, until, maxAttempts, exhausted, mutate)` operator with one-line summary
+- [x] 7.3 XML docs on every `Loop` overload describe: right-rail behaviour, left-passthrough, iteration order, `mutate` cannot fail the rail, exhaustion uses caller's delegate
+- [x] 7.4 Document the per-iteration `Recover` scoping rule with a small example in XML docs or README
+
+## 8. Release Readiness
+
+- [x] 8.1 Run full test suite (`Zooper.Bee.Tests` + `Zooper.Bee.MediatR` tests + example project build) and confirm green
+- [x] 8.2 Build `Zooper.Bee`, `Zooper.Bee.MediatR`, `Zooper.Bee.Example` in Release configuration
+- [x] 8.3 Bump package version (minor bump, e.g. `4.1.0`) since `Loop` is additive on top of the `4.0.0` vNext API
+- [x] 8.4 Read through the retry-with-mutation example to confirm the loop reads as narrative — qualitative success check matching the vNext readability metric


### PR DESCRIPTION
- Introduced Loop operator in RailwayStepsBuilder for first-class bounded iteration.
- Implemented LoopBuilder to support nested right-side sub-pipelines with operators like Do, Tap, Effects, and Branch.
- Defined iteration semantics including body execution, until condition checks, and mutation between iterations.
- Ensured Loop handles Left passthrough and exits on body Lefts, with customizable exhaustion behavior.
- Added comprehensive specs and tests to validate Loop functionality and integration with existing operators.
- Updated documentation and examples to illustrate new Loop capabilities.